### PR TITLE
Remove Negative Margin from Articles Page (along with Eslint fixes)

### DIFF
--- a/apps/pragmatic-papers/src/app/(frontend)/articles/[slug]/page.tsx
+++ b/apps/pragmatic-papers/src/app/(frontend)/articles/[slug]/page.tsx
@@ -53,7 +53,7 @@ export default async function Article({ params: paramsPromise }: Args) {
   if (!article) return <PayloadRedirects url={url} />
 
   return (
-    <article className="pt-16 pb-16 max-w-3xl mx-auto">
+    <article className="pb-16 max-w-3xl mx-auto">
       <PageClient />
 
       {/* Allows redirects for valid pages too */}

--- a/apps/pragmatic-papers/src/heros/PostHero/index.tsx
+++ b/apps/pragmatic-papers/src/heros/PostHero/index.tsx
@@ -14,7 +14,7 @@ export const PostHero: React.FC<{
     populatedAuthors && populatedAuthors.length > 0 && formatAuthors(populatedAuthors) !== ''
 
   return (
-    <div className="relative -mt-[6.4rem] flex items-end">
+    <div className="relative flex items-end">
       <div className="container z-10 relative text-white pb-4 flex-col">
         <h1 className="mb-6 text-4xl text-center font-bold">{title}</h1>
         {hasAuthors && (


### PR DESCRIPTION
IMO negative margins are dark arts left only to be used for some of the most complicated designs. 

This change:
* Removes the negative margin and removes the corresponding padding from the articles page
    * technically this leaves more space than there was before but it was eating into the padding from the header
* Removes the eslint-ignores that were added by me (and updates it to be compliant)


Before:
![Screen Shot 2025-06-29 at 22 55 31](https://github.com/user-attachments/assets/4629e7b1-c1c0-40f1-aaa8-1b7cd45a3e61)


After:
![Screen Shot 2025-06-29 at 22 55 20](https://github.com/user-attachments/assets/cb896095-ca63-4463-ba2f-b4501095527e)
