### PR TITLE
Remove explicit sizing on ArticleCard Images

### DIFF
--- a/apps/pragmatic-papers/src/components/ArticleCard/index.tsx
+++ b/apps/pragmatic-papers/src/components/ArticleCard/index.tsx
@@ -37,7 +37,6 @@ export const ArticleCard: React.FC<{
           {metaImage && typeof metaImage !== 'string' && (
             <Media
               resource={metaImage}
-              size="100vw"
               className="h-full w-full"
               imgClassName="object-cover h-full w-full"
             />


### PR DESCRIPTION
By default this srcset is chosen. Passing 100vw was removing this.

`(max-width: 1920px) 3840w, (max-width: 1536px) 3072w, (max-width: 1280px) 2560w, (max-width: 1024px) 2048w, (max-width: 768px) 1536w, (max-width: 640px) 1280w`