### PR TITLE
Just Use ICO for RSS Feeds

### DIFF
--- a/apps/pragmatic-papers/src/utilities/generateRssFeed.ts
+++ b/apps/pragmatic-papers/src/utilities/generateRssFeed.ts
@@ -66,7 +66,6 @@ const createBaseFeedConfig = (type: 'Articles' | 'Volumes') => ({
   link: SITE_URL,
   language: 'en',
   favicon: `${SITE_URL}/favicon.ico`,
-  image: `${SITE_URL}/pragmaticpapers-logo-dark-og.png`,
   copyright: `All rights reserved ${new Date().getFullYear()}`,
   generator: 'Pragmatic Papers',
   updated: new Date(),


### PR DESCRIPTION
It seems like most readers are looking for an ICO square image anyway.

![Screenshot 2025-07-06 at 7 54 30 PM](https://github.com/user-attachments/assets/88eb71eb-6a12-4370-a5c9-f57ce5dbb2b8)
![Screenshot 2025-07-06 at 7 54 42 PM](https://github.com/user-attachments/assets/3df95da4-6261-49c2-a433-30e07f6d1a64)
