### PR TITLE
Use break word on links

### DIFF
--- a/apps/pragmatic-papers/tailwind.config.mjs
+++ b/apps/pragmatic-papers/tailwind.config.mjs
@@ -163,7 +163,7 @@ const config = {
                 textDecoration: 'none',
                 color: 'inherit',
                 transition: 'box-shadow 0.2s ease-out',
-                wordBreak: 'break-all',
+                wordBreak: 'break-word',
               },
               'a:hover': {
                 boxShadow: 'inset 0 -11px 0 0 var(--brand-light)',


### PR DESCRIPTION
Previously set to `break-all` since links with underscores cause articles to overlap if they are too long.