### PR TITLE
Lightmode Styling Updates

### DIFF
--- a/apps/pragmatic-papers/src/Footer/Component.tsx
+++ b/apps/pragmatic-papers/src/Footer/Component.tsx
@@ -15,17 +15,17 @@ export async function Footer() {
   const navItems = footerData?.navItems || []
 
   return (
-    <footer className="mt-auto border-t border-border bg-black dark:bg-card text-white">
+    <footer className="mt-auto border-t border-border  text-black dark:text-white">
       <div className="container py-8 gap-8 flex flex-col md:flex-row md:justify-between">
         <Link className="flex items-center" href="/">
-          <Logo size="xs" theme={'dark'} />
+          <Logo size="xs" />
         </Link>
 
         <div className="flex flex-col-reverse items-start md:flex-row gap-4 md:items-center">
           <ThemeSelector />
           <nav className="flex flex-col md:flex-row gap-4">
             {navItems.map(({ link }, i) => {
-              return <CMSLink className="text-white" key={i} {...link} />
+              return <CMSLink className="text-black dark:text-white" key={i} {...link} />
             })}
           </nav>
         </div>

--- a/apps/pragmatic-papers/src/app/(frontend)/globals.css
+++ b/apps/pragmatic-papers/src/app/(frontend)/globals.css
@@ -17,7 +17,7 @@
     --brand: #0080ff;
     --brand-light: #56b0ff;
 
-    --background: 0 0% 100%;
+    --background: 0 0% 98%;
     --foreground: 222.2 84% 4.9%;
 
     --card: 240 5% 96%;

--- a/apps/pragmatic-papers/src/components/VolumesView/entry.tsx
+++ b/apps/pragmatic-papers/src/components/VolumesView/entry.tsx
@@ -42,7 +42,7 @@ export const Entry: React.FC<{
       <div className="group">
         <div className="text-left text-sm">
           <span className="pe-2">Volume {toRoman(volumeNumber ?? 1)}</span>
-          <span className="text-brandLight">
+          <span className="text-brand dark:text-brandLight">
             {publishedAt ? dateToString(Date.parse(publishedAt)) : ''}
           </span>
         </div>
@@ -59,7 +59,7 @@ export const Entry: React.FC<{
             </h3>
           )}
           {description && (
-            <div className="my-3 text-sm md:text-base text-gray-400">
+            <div className="my-3 text-sm md:text-base text-muted-foreground">
               {description && <p>{sanitizedDescription}</p>}
             </div>
           )}

--- a/apps/pragmatic-papers/tailwind.config.mjs
+++ b/apps/pragmatic-papers/tailwind.config.mjs
@@ -127,8 +127,11 @@ const config = {
                 marginBottom: '0.25em',
                 color: 'transparent',
                 '-webkit-text-stroke-width': '2px',
-                '-webkit-text-stroke-color': 'var(--brand-light)',
+                '-webkit-text-stroke-color': 'var(--brand)',
                 fontFamily: 'Open Sans,Open Sans Fallback',
+                '[data-theme="dark"] &': {
+                  '-webkit-text-stroke-color': 'var(--brand-light)',
+                },
               },
               h2: {
                 fontSize: '2.25rem',
@@ -180,7 +183,10 @@ const config = {
                 marginBottom: '0.25em',
                 color: 'transparent',
                 '-webkit-text-stroke-width': '2px',
-                '-webkit-text-stroke-color': 'var(--brand-light)',
+                '-webkit-text-stroke-color': 'var(--brand)',
+                '[data-theme="dark"] &': {
+                  '-webkit-text-stroke-color': 'var(--brand-light)',
+                },
               },
             },
           ],


### PR DESCRIPTION
Closes #100 

- Updates footer to be lightmode compatible
- Slightly softens background in lightmode
- uses "brand" instead of "brandLight" for accent text in lightmode.
- Use muted-text instead of specific color of gray
![Screenshot 2025-07-09 at 1 38 35 AM](https://github.com/user-attachments/assets/82c1b5de-82f0-4c22-a593-f5bab637fb74)
![Screenshot 2025-07-09 at 1 38 40 AM](https://github.com/user-attachments/assets/1b0d65e1-2898-4bbf-83bf-19167f81a01f)
