### PR TITLE
Use 3xl as Standard Max Width

### DIFF
--- a/apps/pragmatic-papers/src/app/(frontend)/[slug]/page.tsx
+++ b/apps/pragmatic-papers/src/app/(frontend)/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function Page({
   const { hero, layout } = page
 
   return (
-    <article className="pb-24">
+    <article className="pb-24 max-w-3xl m-auto">
       <PageClient />
       {/* Allows redirects for valid pages too */}
       <PayloadRedirects disableNotFound url={url} />

--- a/apps/pragmatic-papers/src/app/(frontend)/volumes/[slug]/page.tsx
+++ b/apps/pragmatic-papers/src/app/(frontend)/volumes/[slug]/page.tsx
@@ -86,7 +86,7 @@ export default async function VolumePage({
   const actualArticles = articles?.filter((article) => typeof article !== 'number')
 
   return (
-    <div className="pb-16 max-w-2xl px-4 mx-auto">
+    <div className="pb-16 max-w-3xl px-4 mx-auto">
       <PageClient />
 
       {/* Allows redirects for valid pages too */}


### PR DESCRIPTION
Wide content is hard to read, even on large screens. This sets 3xl as the max width for any generic page we create.

- Sets max-w-3xl on generic page slug and auto margin to center it
- Changes volumes to max-3xl to match (This just gives the images a little more breathing room on desktop)


Testing:
Example of prod homepage after change:
![Screenshot 2025-07-09 at 7 25 41 PM](https://github.com/user-attachments/assets/98548b30-d263-40a7-823f-f25a0a42894e)

Before RSS:
![Screenshot 2025-07-09 at 7 29 56 PM](https://github.com/user-attachments/assets/72170380-e266-459b-b90f-040d4c727eb3)
After RSS:
![Screenshot 2025-07-09 at 7 30 11 PM](https://github.com/user-attachments/assets/f3b75465-51ab-4eef-a593-fd1fe8956e26)
