### PR TITLE
Check for width null rather than url

### DIFF
--- a/apps/pragmatic-papers/src/components/Media/ImageMedia/index.tsx
+++ b/apps/pragmatic-papers/src/components/Media/ImageMedia/index.tsx
@@ -81,7 +81,7 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
         Object.values(resource.sizes)
           .filter(
             (resourceSize) =>
-              resourceSize.url &&
+              resourceSize.width &&
               resourceSize !== resource.sizes?.square &&
               resourceSize !== resource.sizes?.og,
           )


### PR DESCRIPTION
Fixing bug where smaller images aren't being scaled up, therefore don't have those sizes available, however are still being listed as a source option.
![image](https://github.com/user-attachments/assets/4560eed2-0a3f-45b4-8966-b6266a1c1e54)
