### PR TITLE
Set param to allow upload to enlarge low res images

### DIFF
--- a/apps/pragmatic-papers/src/collections/Media.ts
+++ b/apps/pragmatic-papers/src/collections/Media.ts
@@ -85,6 +85,7 @@ export const Media: CollectionConfig = {
         formatOptions: {
           format: 'webp',
         },
+        withoutEnlargement: false,
       },
       {
         name: 'square',
@@ -93,6 +94,7 @@ export const Media: CollectionConfig = {
         formatOptions: {
           format: 'webp',
         },
+        withoutEnlargement: false,
       },
       {
         name: 'small',
@@ -100,6 +102,7 @@ export const Media: CollectionConfig = {
         formatOptions: {
           format: 'webp',
         },
+        withoutEnlargement: false,
       },
       {
         name: 'medium',
@@ -107,6 +110,7 @@ export const Media: CollectionConfig = {
         formatOptions: {
           format: 'webp',
         },
+        withoutEnlargement: false,
       },
       {
         name: 'large',
@@ -114,6 +118,7 @@ export const Media: CollectionConfig = {
         formatOptions: {
           format: 'webp',
         },
+        withoutEnlargement: false,
       },
       {
         name: 'xlarge',
@@ -121,6 +126,7 @@ export const Media: CollectionConfig = {
         formatOptions: {
           format: 'webp',
         },
+        withoutEnlargement: false,
       },
       {
         name: 'og',
@@ -130,6 +136,7 @@ export const Media: CollectionConfig = {
         formatOptions: {
           format: 'jpeg',
         },
+        withoutEnlargement: false,
       },
     ],
   },


### PR DESCRIPTION
`withoutEnlargement`
* 1. `undefined` [default]: uploading images with smaller width AND height than the image size will return null
* 2. `false`: always enlarge images to the image size
* 3. `true`: if the image is smaller than the image size, return the original image