### PR TITLE
Added webhooks to Pragmatic Papers

### DIFF
--- a/apps/pragmatic-papers/src/collections/Volumes/hooks/pushToBot.ts
+++ b/apps/pragmatic-papers/src/collections/Volumes/hooks/pushToBot.ts
@@ -34,7 +34,11 @@ export const pushToBot: CollectionAfterChangeHook<Volume> = async (args) => {
       console.error(e)
     })
 
-    if (!res || !res.ok) return
+    if (!res || !res.ok) {
+      console.error(`Request to webhook ${webhook.name} failed`)
+      if (res) console.error(`    ${res.status}: ${res.statusText}`)
+      return
+    }
     const articlesPushed = webhook.pushed ?? []
     articlesPushed.push({ volumeNumber: args.doc.volumeNumber, id: args.doc.id.toString() })
 

--- a/apps/pragmatic-papers/src/collections/Volumes/hooks/pushToBot.ts
+++ b/apps/pragmatic-papers/src/collections/Volumes/hooks/pushToBot.ts
@@ -1,0 +1,45 @@
+import { type Volume } from '@/payload-types'
+import { getPayload, type CollectionAfterChangeHook } from 'payload'
+import config from '@payload-config'
+
+export const pushToBot: CollectionAfterChangeHook<Volume> = async (args) => {
+  if (!args.data.slug || !args.req.host) return
+
+  const url = `${args.req.origin}/volumes/${args.data.slug}`
+  const payload = await getPayload({ config })
+  const webhooks = await payload.find({ collection: 'webhooks' })
+
+  for (const webhook of webhooks.docs) {
+    const latestHasBeenPushed =
+      (webhook.latestVolume && webhook.latestVolume >= args.doc.volumeNumber) ||
+      webhook.pushed?.map((v) => v.id).includes(args.doc.id.toString())
+    if (latestHasBeenPushed) continue
+
+    const res = await fetch(webhook.url, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        content: url,
+        username: 'Pragmatic Papers',
+        // avatar_url: ""
+      }),
+    })
+      .then((r) => r)
+      .catch((e) => {
+        console.error(e)
+      })
+    if (!res || !res.ok) return
+    const articlesPushed = webhook.pushed ?? []
+    articlesPushed.push({ volumeNumber: args.doc.volumeNumber, id: args.doc.id.toString() })
+    payload.update({
+      collection: 'webhooks',
+      id: webhook.id,
+      data: {
+        pushed: articlesPushed,
+        latestVolume: args.data.volumeNumber,
+      },
+    })
+  }
+}

--- a/apps/pragmatic-papers/src/collections/Volumes/index.ts
+++ b/apps/pragmatic-papers/src/collections/Volumes/index.ts
@@ -30,6 +30,7 @@ import {
 import { generatePreviewPath } from '@/utilities/generatePreviewPath'
 import { revalidateArticle, revalidateDelete } from './hooks/revalidateVolumes'
 import { checkArticles } from './hooks/checkArticles'
+import { pushToBot } from './hooks/pushToBot'
 
 export const Volumes: CollectionConfig = {
   slug: 'volumes',
@@ -173,7 +174,7 @@ export const Volumes: CollectionConfig = {
     ...numberSlugField('volumeNumber'),
   ],
   hooks: {
-    afterChange: [revalidateArticle],
+    afterChange: [revalidateArticle, pushToBot],
     afterDelete: [revalidateDelete],
   },
   versions: {

--- a/apps/pragmatic-papers/src/collections/Volumes/index.ts
+++ b/apps/pragmatic-papers/src/collections/Volumes/index.ts
@@ -30,7 +30,7 @@ import {
 import { generatePreviewPath } from '@/utilities/generatePreviewPath'
 import { revalidateArticle, revalidateDelete } from './hooks/revalidateVolumes'
 import { checkArticles } from './hooks/checkArticles'
-import { pushToBot } from './hooks/pushToBot'
+import { pushToWebhooks } from './hooks/pushToWebhooks'
 
 export const Volumes: CollectionConfig = {
   slug: 'volumes',
@@ -174,7 +174,7 @@ export const Volumes: CollectionConfig = {
     ...numberSlugField('volumeNumber'),
   ],
   hooks: {
-    afterChange: [revalidateArticle, pushToBot],
+    afterChange: [revalidateArticle, pushToWebhooks],
     afterDelete: [revalidateDelete],
   },
   versions: {

--- a/apps/pragmatic-papers/src/collections/Webhooks/index.ts
+++ b/apps/pragmatic-papers/src/collections/Webhooks/index.ts
@@ -1,0 +1,50 @@
+import { admin } from '@/access/admins'
+import { type CollectionConfig } from 'payload'
+
+export const Webhooks: CollectionConfig = {
+  slug: 'webhooks',
+  access: {
+    create: admin,
+    delete: admin,
+    read: admin,
+    update: admin,
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: false,
+    },
+    {
+      name: 'url',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'latestVolume',
+      type: 'number',
+      admin: {
+        readOnly: true,
+        hidden: true,
+      },
+    },
+    {
+      name: 'pushed',
+      type: 'array',
+      fields: [
+        {
+          name: 'volumeNumber',
+          type: 'number',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+      ],
+      admin: {
+        readOnly: true,
+        hidden: true,
+      },
+    },
+  ],
+}

--- a/apps/pragmatic-papers/src/collections/Webhooks/index.ts
+++ b/apps/pragmatic-papers/src/collections/Webhooks/index.ts
@@ -1,5 +1,6 @@
 import { admin } from '@/access/admins'
-import { type CollectionConfig } from 'payload'
+import { type Webhook } from '@/payload-types'
+import { type FieldHookArgs, type CollectionConfig } from 'payload'
 
 export const Webhooks: CollectionConfig = {
   slug: 'webhooks',
@@ -21,16 +22,23 @@ export const Webhooks: CollectionConfig = {
       required: true,
     },
     {
-      name: 'latestVolume',
       type: 'number',
-      admin: {
-        readOnly: true,
-        hidden: true,
+      name: 'mostRecentPushed',
+      label: 'Most Recent',
+      hooks: {
+        afterRead: [
+          (ctx: FieldHookArgs<Webhook, unknown, { pushed: { volumeNumber: number }[] }>): number =>
+            Math.max(...(ctx.siblingData.pushed?.map((v) => v.volumeNumber) ?? [])),
+        ],
       },
     },
     {
       name: 'pushed',
       type: 'array',
+      labels: {
+        plural: 'volumes',
+        singular: 'volume',
+      },
       fields: [
         {
           name: 'volumeNumber',

--- a/apps/pragmatic-papers/src/collections/Webhooks/index.ts
+++ b/apps/pragmatic-papers/src/collections/Webhooks/index.ts
@@ -22,13 +22,21 @@ export const Webhooks: CollectionConfig = {
       required: true,
     },
     {
-      type: 'number',
+      type: 'text',
       name: 'mostRecentPushed',
       label: 'Most Recent',
       hooks: {
         afterRead: [
-          (ctx: FieldHookArgs<Webhook, unknown, { pushed: { volumeNumber: number }[] }>): number =>
-            Math.max(...(ctx.siblingData.pushed?.map((v) => v.volumeNumber) ?? [0])),
+          (
+            ctx: FieldHookArgs<Webhook, unknown, { pushed: { volumeNumber: number }[] }>,
+          ): string => {
+            return (
+              ctx.data?.pushed
+                ?.map((v) => v.volumeNumber ?? 0)
+                .reduce((prev, curr) => (prev > curr ? prev : curr))
+                ?.toString() ?? '-'
+            )
+          },
         ],
       },
     },

--- a/apps/pragmatic-papers/src/collections/Webhooks/index.ts
+++ b/apps/pragmatic-papers/src/collections/Webhooks/index.ts
@@ -28,7 +28,7 @@ export const Webhooks: CollectionConfig = {
       hooks: {
         afterRead: [
           (ctx: FieldHookArgs<Webhook, unknown, { pushed: { volumeNumber: number }[] }>): number =>
-            Math.max(...(ctx.siblingData.pushed?.map((v) => v.volumeNumber) ?? [])),
+            Math.max(...(ctx.siblingData.pushed?.map((v) => v.volumeNumber) ?? [0])),
         ],
       },
     },

--- a/apps/pragmatic-papers/src/collections/Webhooks/index.ts
+++ b/apps/pragmatic-papers/src/collections/Webhooks/index.ts
@@ -39,6 +39,10 @@ export const Webhooks: CollectionConfig = {
           },
         ],
       },
+      admin: {
+        readOnly: true,
+        description: 'The most recent volume number that has been pushed to this webhook',
+      },
     },
     {
       name: 'pushed',

--- a/apps/pragmatic-papers/src/payload-types.ts
+++ b/apps/pragmatic-papers/src/payload-types.ts
@@ -814,7 +814,7 @@ export interface Webhook {
   id: number;
   name?: string | null;
   url: string;
-  latestVolume?: number | null;
+  mostRecentPushed?: number | null;
   pushed?:
     | {
         volumeNumber?: number | null;
@@ -1390,7 +1390,7 @@ export interface UsersSelect<T extends boolean = true> {
 export interface WebhooksSelect<T extends boolean = true> {
   name?: T;
   url?: T;
-  latestVolume?: T;
+  mostRecentPushed?: T;
   pushed?:
     | T
     | {

--- a/apps/pragmatic-papers/src/payload-types.ts
+++ b/apps/pragmatic-papers/src/payload-types.ts
@@ -73,6 +73,7 @@ export interface Config {
     media: Media;
     categories: Category;
     users: User;
+    webhooks: Webhook;
     redirects: Redirect;
     forms: Form;
     'form-submissions': FormSubmission;
@@ -89,6 +90,7 @@ export interface Config {
     media: MediaSelect<false> | MediaSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
+    webhooks: WebhooksSelect<false> | WebhooksSelect<true>;
     redirects: RedirectsSelect<false> | RedirectsSelect<true>;
     forms: FormsSelect<false> | FormsSelect<true>;
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
@@ -806,6 +808,24 @@ export interface Category {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "webhooks".
+ */
+export interface Webhook {
+  id: number;
+  name?: string | null;
+  url: string;
+  latestVolume?: number | null;
+  pushed?:
+    | {
+        volumeNumber?: number | null;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "redirects".
  */
 export interface Redirect {
@@ -973,6 +993,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'users';
         value: number | User;
+      } | null)
+    | ({
+        relationTo: 'webhooks';
+        value: number | Webhook;
       } | null)
     | ({
         relationTo: 'redirects';
@@ -1358,6 +1382,23 @@ export interface UsersSelect<T extends boolean = true> {
         createdAt?: T;
         expiresAt?: T;
       };
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "webhooks_select".
+ */
+export interface WebhooksSelect<T extends boolean = true> {
+  name?: T;
+  url?: T;
+  latestVolume?: T;
+  pushed?:
+    | T
+    | {
+        volumeNumber?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/apps/pragmatic-papers/src/payload-types.ts
+++ b/apps/pragmatic-papers/src/payload-types.ts
@@ -814,7 +814,7 @@ export interface Webhook {
   id: number;
   name?: string | null;
   url: string;
-  mostRecentPushed?: number | null;
+  mostRecentPushed?: string | null;
   pushed?:
     | {
         volumeNumber?: number | null;

--- a/apps/pragmatic-papers/src/payload-types.ts
+++ b/apps/pragmatic-papers/src/payload-types.ts
@@ -814,10 +814,14 @@ export interface Webhook {
   id: number;
   name?: string | null;
   url: string;
-  mostRecentPushed?: string | null;
+  /**
+   * The most recent volume number that has been pushed to this webhook
+   */
+  mostRecent?: string | null;
   pushed?:
     | {
         volumeNumber?: number | null;
+        timePushed?: string | null;
         id?: string | null;
       }[]
     | null;
@@ -1390,11 +1394,12 @@ export interface UsersSelect<T extends boolean = true> {
 export interface WebhooksSelect<T extends boolean = true> {
   name?: T;
   url?: T;
-  mostRecentPushed?: T;
+  mostRecent?: T;
   pushed?:
     | T
     | {
         volumeNumber?: T;
+        timePushed?: T;
         id?: T;
       };
   updatedAt?: T;

--- a/apps/pragmatic-papers/src/payload.config.ts
+++ b/apps/pragmatic-papers/src/payload.config.ts
@@ -17,6 +17,7 @@ import { defaultLexical } from '@/fields/defaultLexical'
 import { getServerSideURL } from './utilities/getURL'
 import { Articles } from './collections/Articles'
 import { Volumes } from './collections/Volumes'
+import { Webhooks } from './collections/Webhooks'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -70,7 +71,7 @@ export default buildConfig({
             url: process.env.DATABASE_URI || '',
           },
         }),
-  collections: [Pages, Articles, Volumes, Media, Categories, Users],
+  collections: [Pages, Articles, Volumes, Media, Categories, Users, Webhooks],
   cors: [getServerSideURL()].filter(Boolean),
   globals: [Header, Footer],
   plugins: [...plugins],


### PR DESCRIPTION
notes: as of now, the key `fetch` call is aimed at the [discord api](https://discord.com/developers/docs/resources/webhook#execute-webhook). avatar URL could probably be moved to a more accessible spot, the check for whether or not to actually push a webhook event could probably be more sophisticated. at the moment it's a volume going draft -> published while having no previous publication date (i.e. the first publish)

this *just* pushes the raw URL, nothing fancy. having a bot grab it and do fancy stuff is probably the play, as of right now you could "add webhook" in the discord server and the message would be the URL (with a username / avatar override)

partially addresses #119 / #76