### PR TITLE
remove update-server-count-job from start-manager.ts, remove template owner stream and paypal links

### DIFF
--- a/apps/discord-bot/lang/lang.common.json
+++ b/apps/discord-bot/lang/lang.common.json
@@ -25,7 +25,7 @@
   "links": {
     "author": "https://github.com/",
     "docs": "https://top.gg/",
-    "donate": "",
+    "donate": " ",
     "invite": "https://discord.com/",
     "source": "https://github.com/",
     "stream": "",

--- a/apps/discord-bot/lang/lang.common.json
+++ b/apps/discord-bot/lang/lang.common.json
@@ -25,10 +25,10 @@
   "links": {
     "author": "https://github.com/",
     "docs": "https://top.gg/",
-    "donate": "https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=EW389DYYSS4FC",
+    "donate": "",
     "invite": "https://discord.com/",
     "source": "https://github.com/",
-    "stream": "https://www.twitch.tv/novakevin",
+    "stream": "",
     "support": "https://support.discord.com/",
     "template": "https://github.com/KevinNovak/Discord-Bot-TypeScript-Template",
     "terms": "https://github.com/KevinNovak/Discord-Bot-TypeScript-Template/blob/master/LEGAL.md#terms-of-service",

--- a/apps/discord-bot/src/start-manager.ts
+++ b/apps/discord-bot/src/start-manager.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module'
 import 'reflect-metadata'
 
 import { GuildsController, RootController, ShardsController } from './controllers/index.js'
-import { type Job, UpdateServerCountJob } from './jobs/index.js'
+import { type Job } from './jobs/index.js'
 import { Api } from './models/api.js'
 import { Manager } from './models/manager.js'
 import { HttpService, JobService, Logger, MasterApiService } from './services/index.js'

--- a/apps/discord-bot/src/start-manager.ts
+++ b/apps/discord-bot/src/start-manager.ts
@@ -61,7 +61,7 @@ async function start(): Promise<void> {
 
   // Jobs
   const jobs = [
-    Config.clustering.enabled ? undefined : new UpdateServerCountJob(shardManager, httpService),
+    // Config.clustering.enabled ? undefined : new UpdateServerCountJob(shardManager, httpService),
     // TODO: Add new jobs here
   ].filter(Boolean) as Job[]
 


### PR DESCRIPTION
This function sets the bot's activity to "Streaming to ${Server_count} servers"

We also don't plan on putting this bot on any other servers so there's no need for this job to run.

closes https://github.com/dggpoliticalaction/org-repo/issues/161