### PR TITLE
Updates base squiggle component with size prop

### DIFF
--- a/apps/pragmatic-papers/src/blocks/SquiggleRule/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/SquiggleRule/Component.tsx
@@ -1,6 +1,5 @@
 import type { SquiggleRuleBlock as SquiggleRuleBlockProps } from 'src/payload-types'
 
-import { cn } from '@/utilities/ui'
 import React from 'react'
 import { Squiggle, SquiggleStatic } from '@/components/ui/squiggle'
 
@@ -11,16 +10,5 @@ type Props = {
 export const SquiggleRuleBlock: React.FC<Props> = ({ className, variant, size }) => {
   const SquiggleComponent = variant === 'static' ? SquiggleStatic : Squiggle
 
-  const sizeClasses = {
-    small: 'max-w-xs',
-    medium: 'max-w-md',
-    large: 'max-w-lg',
-    full: 'w-full',
-  }
-
-  return (
-    <div className={cn('mx-auto my-8', sizeClasses[size || 'medium'], className)}>
-      <SquiggleComponent />
-    </div>
-  )
+  return <SquiggleComponent className={className} size={size || 'medium'} />
 }

--- a/apps/pragmatic-papers/src/components/VolumesView/entry.tsx
+++ b/apps/pragmatic-papers/src/components/VolumesView/entry.tsx
@@ -9,7 +9,6 @@ import type { Volume } from '@/payload-types'
 import { formatWithOptions } from 'date-fns/fp'
 import { enUS } from 'date-fns/locale'
 
-import { SquiggleStatic } from '@/components/ui/squiggle'
 import { toRoman } from '@/utilities/toRoman'
 
 // import { Media } from '@/components/Media'
@@ -63,7 +62,6 @@ export const Entry: React.FC<{
               {description && <p>{sanitizedDescription}</p>}
             </div>
           )}
-          <SquiggleStatic />
         </div>
       </div>
     </article>

--- a/apps/pragmatic-papers/src/components/VolumesView/index.tsx
+++ b/apps/pragmatic-papers/src/components/VolumesView/index.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/utilities/ui'
 import React from 'react'
 
 import { Entry, type EntryVolumeData } from './entry'
-
+import { SquiggleStatic } from '@/components/ui/squiggle'
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type Props = {
   volumes: EntryVolumeData[]
@@ -19,7 +19,8 @@ export const VolumesView: React.FC<Props> = (props) => {
             if (typeof result === 'object' && result !== null) {
               return (
                 <div className="pt-3" key={index}>
-                  <Entry className="h-full" doc={result} relationTo="volumes" />
+                  <Entry doc={result} relationTo="volumes" />
+                  {index + 1 !== volumes.length ? <SquiggleStatic size="full" /> : null}
                 </div>
               )
             }

--- a/apps/pragmatic-papers/src/components/ui/squiggle.tsx
+++ b/apps/pragmatic-papers/src/components/ui/squiggle.tsx
@@ -3,25 +3,41 @@
 import { cn } from '@/utilities/ui'
 import * as React from 'react'
 
-const SquiggleStatic: React.FC<{ className?: string }> = ({ className }) => {
+const sizeClasses = {
+  small: 'max-w-xs',
+  medium: 'max-w-md',
+  large: 'max-w-lg',
+  full: 'w-full',
+}
+
+type Size = keyof typeof sizeClasses
+
+interface SquiggleProps {
+  className?: string
+  size?: Size
+}
+
+const SquiggleStatic: React.FC<SquiggleProps> = ({ className, size = 'small' }) => {
   return (
-    <div
-      className={cn(
-        'bg-[url(/squiggle-static.svg)] w-full h-1 mt-6 bg-[length:auto_4px] bg-repeat-x bg-[left_calc(100%)_top_calc(100%)] relative block',
-        className,
-      )}
-    />
+    <div className={cn('mx-auto my-8', sizeClasses[size], className)}>
+      <div
+        className={cn(
+          'bg-[url(/squiggle-static.svg)] w-full h-1 bg-[length:auto_4px] bg-repeat-x bg-[left_calc(100%)_top_calc(100%)] relative block',
+        )}
+      />
+    </div>
   )
 }
 
-const Squiggle: React.FC<{ className?: string }> = ({ className }) => {
+const Squiggle: React.FC<SquiggleProps> = ({ className, size = 'small' }) => {
   return (
-    <div
-      className={cn(
-        'bg-[url(/squiggle.svg)] w-full h-1 bg-[length:auto_4px] bg-repeat-x bg-[left_calc(100%)_top_calc(100%)] relative block',
-        className,
-      )}
-    />
+    <div className={cn('mx-auto my-8', sizeClasses[size], className)}>
+      <div
+        className={cn(
+          'bg-[url(/squiggle.svg)] w-full h-1 bg-[length:auto_4px] bg-repeat-x bg-[left_calc(100%)_top_calc(100%)] relative block',
+        )}
+      />
+    </div>
   )
 }
 


### PR DESCRIPTION
#### Squiggle Sizing
Moves the size prop which was previously just on the Block, to the actual base component, to allow for consistent sizing of the squiggle component regardless of where it's used, inside of blocks or inside of sub-components.

In this case, the Squiggle component was used within the `VolumesView` component as a divider between the volumes, pervious,  before this change it the `max-width` was constrained by it's parent component meaning it would be different wherever used unless properly sized.

#### Squiggle moved to index for volumes
Instead of rendering the squiggle in the Volumes View Entry component, I moved it to the index, so we can hide it from the last one a bit easier.