### PR TITLE
Adds align feature to lexical rich text editor

### DIFF
--- a/apps/pragmatic-papers/src/app/(payload)/admin/importMap.js
+++ b/apps/pragmatic-papers/src/app/(payload)/admin/importMap.js
@@ -27,6 +27,7 @@ import { BlockquoteFeatureClient as BlockquoteFeatureClient_e70f5e05f09f93e00b99
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { default as default_80e5fdb60df5ca84bc544282529ce3be } from '../../../blocks/Math/AdminComponent'
+import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { NumberSlugComponent as NumberSlugComponent_9af2be3fdd2360e76f1d8ca7ed18129c } from '@/fields/numberSlug/SlugComponent'
 import { RowLabel as RowLabel_ec255a65fa6fa8d1faeb09cf35284224 } from '@/Header/RowLabel'
 import { RowLabel as RowLabel_1f6ff6ff633e3695d348f4f3c58f1466 } from '@/Footer/RowLabel'
@@ -64,6 +65,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "/blocks/Math/AdminComponent#default": default_80e5fdb60df5ca84bc544282529ce3be,
+  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@/fields/numberSlug/SlugComponent#NumberSlugComponent": NumberSlugComponent_9af2be3fdd2360e76f1d8ca7ed18129c,
   "@/Header/RowLabel#RowLabel": RowLabel_ec255a65fa6fa8d1faeb09cf35284224,
   "@/Footer/RowLabel#RowLabel": RowLabel_1f6ff6ff633e3695d348f4f3c58f1466,

--- a/apps/pragmatic-papers/src/collections/Articles/index.ts
+++ b/apps/pragmatic-papers/src/collections/Articles/index.ts
@@ -1,6 +1,7 @@
 import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload'
 
 import {
+  AlignFeature,
   BlockquoteFeature,
   BlocksFeature,
   ChecklistFeature,
@@ -92,6 +93,7 @@ export const Articles: CollectionConfig = {
                 features: ({ rootFeatures }) => {
                   return [
                     ...rootFeatures,
+                    AlignFeature(),
                     HeadingFeature({ enabledHeadingSizes: ['h1', 'h2', 'h3', 'h4'] }),
                     BlocksFeature({
                       blocks: [Banner, Code, MediaBlock, DisplayMathBlock, SquiggleRule],

--- a/apps/pragmatic-papers/src/collections/Volumes/index.ts
+++ b/apps/pragmatic-papers/src/collections/Volumes/index.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
 import {
+  AlignFeature,
   BlockquoteFeature,
   BlocksFeature,
   FixedToolbarFeature,
@@ -93,6 +94,7 @@ export const Volumes: CollectionConfig = {
                 features: ({ rootFeatures }) => {
                   return [
                     ...rootFeatures,
+                    AlignFeature(),
                     HeadingFeature({ enabledHeadingSizes: ['h1', 'h2', 'h3', 'h4'] }),
                     BlocksFeature({ blocks: [Banner, Code, MediaBlock, SquiggleRule] }),
                     FixedToolbarFeature(),

--- a/apps/pragmatic-papers/tailwind.config.mjs
+++ b/apps/pragmatic-papers/tailwind.config.mjs
@@ -133,21 +133,18 @@ const config = {
               h2: {
                 fontSize: '2.25rem',
                 fontWeight: 700,
-                textAlign: 'center',
                 lineHeight: 1.2,
                 letterSpacing: 0,
               },
               h3: {
                 fontSize: '1.5rem',
                 fontWeight: 700,
-                textAlign: 'center',
                 lineHeight: 1.2,
                 letterSpacing: 0,
               },
               h4: {
                 fontSize: '1.25rem',
                 fontWeight: 700,
-                textAlign: 'left',
                 lineHeight: '30px',
                 letterSpacing: 0,
               },


### PR DESCRIPTION
This feature was missing, so it's been re-added, some of the articles require this, there were some styles in `tailwind.config.mjs` that were overriding header alignment, so those needed to be removed as well.