### PR TITLE
Add twitter embeds to Pragmatic Papers

### DIFF
--- a/apps/pragmatic-papers/package.json
+++ b/apps/pragmatic-papers/package.json
@@ -54,6 +54,7 @@
     "lucide-react": "^0.378.0",
     "next": "^15.3.5",
     "next-sitemap": "^4.2.3",
+    "node-cache": "^5.1.2",
     "payload": "3.46.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.1.0",

--- a/apps/pragmatic-papers/src/blocks/TwitterEmbed/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/TwitterEmbed/Component.tsx
@@ -1,0 +1,20 @@
+import { TwitterEmbed } from '@/components/TwitterEmbed'
+import type { TwitterEmbedBlock as TwitterEmbedBlockProps } from 'src/payload-types'
+
+type Props = {
+  url?: string
+} & TwitterEmbedBlockProps
+
+export const TwitterEmbedBlock: React.FC<Props> = (props) => {
+  return (
+    <div>
+      <TwitterEmbed
+        url={props.url}
+        maxWidth={props.maxWidth}
+        hideMedia={props.hideMedia || false}
+        hideThread={props.hideThread || false}
+        align={props.align || 'none'}
+        lang={props.lang} />
+    </div>
+  )
+}

--- a/apps/pragmatic-papers/src/blocks/TwitterEmbed/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/TwitterEmbed/Component.tsx
@@ -7,12 +7,10 @@ type Props = {
 
 export const TwitterEmbedBlock: React.FC<Props> = (props) => {
   return (
-    <div>
-      <TwitterEmbed
-        url={props.url}
-        hideMedia={props.hideMedia || false}
-        hideThread={props.hideThread || false}
-        align={props.align || 'none'} />
-    </div>
+    <TwitterEmbed
+      url={props.url}
+      hideMedia={props.hideMedia || false}
+      hideThread={props.hideThread || false}
+      align={props.align || 'none'} />
   )
 }

--- a/apps/pragmatic-papers/src/blocks/TwitterEmbed/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/TwitterEmbed/Component.tsx
@@ -10,11 +10,9 @@ export const TwitterEmbedBlock: React.FC<Props> = (props) => {
     <div>
       <TwitterEmbed
         url={props.url}
-        maxWidth={props.maxWidth}
         hideMedia={props.hideMedia || false}
         hideThread={props.hideThread || false}
-        align={props.align || 'none'}
-        lang={props.lang} />
+        align={props.align || 'none'} />
     </div>
   )
 }

--- a/apps/pragmatic-papers/src/blocks/TwitterEmbed/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/TwitterEmbed/Component.tsx
@@ -11,6 +11,6 @@ export const TwitterEmbedBlock: React.FC<Props> = (props) => {
       url={props.url}
       hideMedia={props.hideMedia || false}
       hideThread={props.hideThread || false}
-      align={props.align || 'none'} />
+      align="center" />
   )
 }

--- a/apps/pragmatic-papers/src/blocks/TwitterEmbed/config.ts
+++ b/apps/pragmatic-papers/src/blocks/TwitterEmbed/config.ts
@@ -29,20 +29,5 @@ export const TwitterEmbed: Block = {
       ],
       defaultValue: 'none'
     },
-    {
-      name: 'lang',
-      type: 'text',
-      maxLength: 2,
-      defaultValue: 'en',
-      required: true
-    },
-    {
-      name: 'maxWidth',
-      type: 'number',
-      min: 220,
-      max: 550,
-      defaultValue: 550,
-      required: true
-    },
   ]
 }

--- a/apps/pragmatic-papers/src/blocks/TwitterEmbed/config.ts
+++ b/apps/pragmatic-papers/src/blocks/TwitterEmbed/config.ts
@@ -1,0 +1,48 @@
+import type { Block } from 'payload'
+
+export const TwitterEmbed: Block = {
+  slug: 'twitterEmbed',
+  interfaceName: 'TwitterEmbedBlock',
+  fields: [
+    {
+      name: 'url',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'hideMedia',
+      type: 'checkbox',
+    },
+    {
+      name: 'hideThread',
+      type: 'checkbox',
+      
+    },
+    {
+      name: 'align',
+      type: 'radio',
+      options: [
+        { label: 'None', value: 'none' },
+        { label: 'Left', value: 'left' },
+        { label: 'Center', value: 'center' },
+        { label: 'Right', value: 'right' },
+      ],
+      defaultValue: 'none'
+    },
+    {
+      name: 'lang',
+      type: 'text',
+      maxLength: 2,
+      defaultValue: 'en',
+      required: true
+    },
+    {
+      name: 'maxWidth',
+      type: 'number',
+      min: 220,
+      max: 550,
+      defaultValue: 550,
+      required: true
+    },
+  ]
+}

--- a/apps/pragmatic-papers/src/blocks/TwitterEmbed/config.ts
+++ b/apps/pragmatic-papers/src/blocks/TwitterEmbed/config.ts
@@ -18,16 +18,5 @@ export const TwitterEmbed: Block = {
       type: 'checkbox',
       
     },
-    {
-      name: 'align',
-      type: 'radio',
-      options: [
-        { label: 'None', value: 'none' },
-        { label: 'Left', value: 'left' },
-        { label: 'Center', value: 'center' },
-        { label: 'Right', value: 'right' },
-      ],
-      defaultValue: 'none'
-    },
   ]
 }

--- a/apps/pragmatic-papers/src/collections/Articles/index.ts
+++ b/apps/pragmatic-papers/src/collections/Articles/index.ts
@@ -40,6 +40,7 @@ import { editorFieldLevel } from '@/access/editor'
 import { type Article } from '@/payload-types'
 import { DisplayMathBlock, InlineMathBlock } from '@/blocks/Math/config'
 import { SquiggleRule } from '@/blocks/SquiggleRule/config'
+import { TwitterEmbed } from '@/blocks/TwitterEmbed/config'
 export const Articles: CollectionConfig = {
   slug: 'articles',
   access: {
@@ -94,7 +95,14 @@ export const Articles: CollectionConfig = {
                     ...rootFeatures,
                     HeadingFeature({ enabledHeadingSizes: ['h1', 'h2', 'h3', 'h4'] }),
                     BlocksFeature({
-                      blocks: [Banner, Code, MediaBlock, DisplayMathBlock, SquiggleRule],
+                      blocks: [
+                        Banner,
+                        Code,
+                        MediaBlock,
+                        DisplayMathBlock,
+                        SquiggleRule,
+                        TwitterEmbed
+                      ],
                       inlineBlocks: [InlineMathBlock],
                     }),
                     FixedToolbarFeature(),

--- a/apps/pragmatic-papers/src/components/RichText/index.tsx
+++ b/apps/pragmatic-papers/src/components/RichText/index.tsx
@@ -19,11 +19,13 @@ import type {
   CallToActionBlock as CTABlockProps,
   SquiggleRuleBlock as SquiggleRuleBlockProps,
   MediaBlock as MediaBlockProps,
+  TwitterEmbedBlock as TwitterEmbedBlockProps,
 } from '@/payload-types'
 import { BannerBlock } from '@/blocks/Banner/Component'
 import { CallToActionBlock } from '@/blocks/CallToAction/Component'
 import { cn } from '@/utilities/ui'
 import { MathBlock, type MathBlockProps } from '@/blocks/Math/Component'
+import { TwitterEmbedBlock } from '@/blocks/TwitterEmbed/Component'
 
 type NodeTypes =
   | DefaultNodeTypes
@@ -34,6 +36,7 @@ type NodeTypes =
       | CodeBlockProps
       | MathBlockProps
       | SquiggleRuleBlockProps
+      | TwitterEmbedBlockProps
     >
 
 const internalDocToHref = ({ linkNode }: { linkNode: SerializedLinkNode }) => {
@@ -66,6 +69,7 @@ const jsxConverters: JSXConvertersFunction<NodeTypes> = ({ defaultConverters }) 
       <MathBlock {...node.fields} />
     ),
     squiggleRule: ({ node }) => <SquiggleRuleBlock className="col-start-2" {...node.fields} />,
+    twitterEmbed: ({ node }) => <TwitterEmbedBlock {...node.fields} />,
   },
   inlineBlocks: {
     inlineMathBlock: ({ node }: { node: SerializedBlockNode<MathBlockProps> }) => (

--- a/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
+++ b/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
@@ -27,7 +27,6 @@ export const TwitterEmbed: React.FC<{
       hide_media: props.hideMedia,
       hide_thread: props.hideThread,
       align: props.align,
-      lang: props.lang,
       maxwidth: props.maxWidth,
       theme: theme as ('light' | 'dark')
     })

--- a/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
+++ b/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-danger */
 'use client'
 
 import type React from 'react';
@@ -53,7 +52,8 @@ export const TwitterEmbed: React.FC<{
   return (
     <div>
       <Script src="https://platform.twitter.com/widgets.js" />
-      /* This shouldn't be dangerous as the HTML is coming from Payload after it's retrieved from the X oEmbed API. */
+      {/* This shouldn't be dangerous as the HTML is coming from Payload after it's retrieved from the X oEmbed API. */}
+      {/* eslint-disable-next-line react/no-danger */}
       <div dangerouslySetInnerHTML={{ __html: content }} ref={contentRef} />
     </div>
   )

--- a/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
+++ b/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
@@ -19,13 +19,17 @@ export const TwitterEmbed: React.FC<{
 
   useEffect(() => {
     if (!props.url) return
+
+    const theme = document.getElementsByTagName('html')[0]?.getAttribute('data-theme') ?? 'dark'
+
     fetchTwitterEmbed({
       url: props.url,
       hide_media: props.hideMedia,
       hide_thread: props.hideThread,
       align: props.align,
       lang: props.lang,
-      maxwidth: props.maxWidth
+      maxwidth: props.maxWidth,
+      theme: theme as ('light' | 'dark')
     })
       .then(res => {
         if (!res) {

--- a/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
+++ b/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import type React from 'react';
+import { useEffect, useRef, useState } from 'react'
+import Script from 'next/script';
+
+import { fetchTwitterEmbed } from '@/utilities/fetchTwitterEmbed';
+
+export const TwitterEmbed: React.FC<{
+  url?: string,
+  hideMedia?: boolean,
+  hideThread?: boolean,
+  align?: ('none' | 'left' | 'center' | 'right') | undefined,
+  lang?: string | undefined,
+  maxWidth?: number | undefined,
+}> = (props) => {
+  const [content, setContent] = useState<string>('')
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!props.url) return
+    fetchTwitterEmbed({
+      url: props.url,
+      hide_media: props.hideMedia,
+      hide_thread: props.hideThread,
+      align: props.align,
+      lang: props.lang,
+      maxwidth: props.maxWidth
+    })
+      .then(res => {
+        if (!res) {
+          setContent('X post could not be loaded.')
+        } else {
+          setContent(res.html)
+        }
+      })
+  }, [props])
+
+  useEffect(() => {
+    if (contentRef.current && window.twttr) {
+      setTimeout(() => window.twttr.widgets.load(contentRef.current), 2000)
+    }
+  }, [content])
+
+  return (
+    <div>
+      <Script src="https://platform.twitter.com/widgets.js" />
+      <div dangerouslySetInnerHTML={{ __html: content }} ref={contentRef} />
+    </div>
+  )
+}

--- a/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
+++ b/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 'use client'
 
 import type React from 'react';
@@ -52,6 +53,7 @@ export const TwitterEmbed: React.FC<{
   return (
     <div>
       <Script src="https://platform.twitter.com/widgets.js" />
+      /* This shouldn't be dangerous as the HTML is coming from Payload after it's retrieved from the X oEmbed API. */
       <div dangerouslySetInnerHTML={{ __html: content }} ref={contentRef} />
     </div>
   )

--- a/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
+++ b/apps/pragmatic-papers/src/components/TwitterEmbed/index.tsx
@@ -38,7 +38,10 @@ export const TwitterEmbed: React.FC<{
 
   useEffect(() => {
     if (contentRef.current && window.twttr) {
-      setTimeout(() => window.twttr.widgets.load(contentRef.current), 2000)
+      // There's a race condition where the content returned by oEmbed needs to be inserted into the page, after which
+      // the twitter JS will load it and render it as an embed instead of just a blockquote. Providing this timeout
+      // helps to make sure the JS has actually loaded.
+      setTimeout(() => window.twttr.widgets.load(contentRef.current), 1000)
     }
   }, [content])
 

--- a/apps/pragmatic-papers/src/payload-types.ts
+++ b/apps/pragmatic-papers/src/payload-types.ts
@@ -1840,8 +1840,6 @@ export interface TwitterEmbedBlock {
   hideMedia?: boolean | null;
   hideThread?: boolean | null;
   align?: ('none' | 'left' | 'center' | 'right') | null;
-  lang: string;
-  maxWidth: number;
   id?: string | null;
   blockName?: string | null;
   blockType: 'twitterEmbed';

--- a/apps/pragmatic-papers/src/payload-types.ts
+++ b/apps/pragmatic-papers/src/payload-types.ts
@@ -1839,7 +1839,6 @@ export interface TwitterEmbedBlock {
   url: string;
   hideMedia?: boolean | null;
   hideThread?: boolean | null;
-  align?: ('none' | 'left' | 'center' | 'right') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'twitterEmbed';

--- a/apps/pragmatic-papers/src/payload-types.ts
+++ b/apps/pragmatic-papers/src/payload-types.ts
@@ -1833,6 +1833,21 @@ export interface SquiggleRuleBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TwitterEmbedBlock".
+ */
+export interface TwitterEmbedBlock {
+  url: string;
+  hideMedia?: boolean | null;
+  hideThread?: boolean | null;
+  align?: ('none' | 'left' | 'center' | 'right') | null;
+  lang: string;
+  maxWidth: number;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'twitterEmbed';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "InlineMathBlock".
  */
 export interface InlineMathBlock {

--- a/apps/pragmatic-papers/src/utilities/fetchTwitterEmbed.ts
+++ b/apps/pragmatic-papers/src/utilities/fetchTwitterEmbed.ts
@@ -33,6 +33,7 @@ async function getTweet(options: TwitterEmbedOptions): Promise<any> {
     align: options.align!,
     lang: options.lang!,
     theme: options.theme!,
+    dnt: 'true',
   })
   const oembedUrl = `https://publish.twitter.com/oembed?${queryParams.toString()}`
   const res = await fetch(oembedUrl)

--- a/apps/pragmatic-papers/src/utilities/fetchTwitterEmbed.ts
+++ b/apps/pragmatic-papers/src/utilities/fetchTwitterEmbed.ts
@@ -1,0 +1,46 @@
+'use server'
+
+export interface TwitterEmbedOptions {
+  url: string,
+  maxwidth?: number,
+  hide_media?: boolean,
+  hide_thread?: boolean,
+  align?: 'left' | 'right' | 'center' | 'none',
+  lang?: string,
+  theme?: 'light' | 'dark'
+}
+
+const DEFAULT_OPTIONS: TwitterEmbedOptions = {
+  url: '',
+  maxwidth: 550,
+  hide_media: false,
+  hide_thread: false,
+  align: 'none',
+  lang: 'en',
+  theme: 'light'
+}
+
+export async function fetchTwitterEmbed(options: TwitterEmbedOptions): Promise<any> {
+  const finalOptions = { ...DEFAULT_OPTIONS, ...options }
+  const queryParams = new URLSearchParams({
+    url: options.url,
+    maxwidth: finalOptions.maxwidth!.toString(),
+    hide_media: String(finalOptions.hide_media!),
+    hide_thread: String(finalOptions.hide_thread!),
+    align: finalOptions.align!,
+    lang: finalOptions.lang!,
+    theme: finalOptions.theme!,
+  })
+  const oembedUrl = `https://publish.twitter.com/oembed?${queryParams.toString()}`
+  try {
+    const res = await fetch(oembedUrl);
+    if (!res.ok) {
+      console.error(`Unable to fetch tweet: ${options.url}`)
+      return null
+    }
+    return await res.json()
+  } catch (exception) {
+    console.error(exception)
+    return null
+  }
+}

--- a/apps/pragmatic-papers/src/utilities/fetchTwitterEmbed.ts
+++ b/apps/pragmatic-papers/src/utilities/fetchTwitterEmbed.ts
@@ -8,7 +8,6 @@ export interface TwitterEmbedOptions {
   hide_media?: boolean,
   hide_thread?: boolean,
   align?: 'left' | 'right' | 'center' | 'none',
-  lang?: string,
   theme?: 'light' | 'dark'
 }
 
@@ -18,7 +17,6 @@ const DEFAULT_OPTIONS: TwitterEmbedOptions = {
   hide_media: false,
   hide_thread: false,
   align: 'none',
-  lang: 'en',
   theme: 'light'
 }
 
@@ -45,7 +43,6 @@ async function getTweet(options: TwitterEmbedOptions): Promise<TwitterEmbedData>
     hide_media: String(options.hide_media!),
     hide_thread: String(options.hide_thread!),
     align: options.align!,
-    lang: options.lang!,
     theme: options.theme!,
     dnt: 'true',
   })

--- a/apps/pragmatic-papers/src/utilities/fetchTwitterEmbed.ts
+++ b/apps/pragmatic-papers/src/utilities/fetchTwitterEmbed.ts
@@ -22,9 +22,23 @@ const DEFAULT_OPTIONS: TwitterEmbedOptions = {
   theme: 'light'
 }
 
+interface TwitterEmbedData {
+  url: string,
+  author_name: string,
+  author_url: string,
+  html: string,
+  width: number,
+  height?: number,
+  type: string,
+  cache_age: number,
+  provider_name: string,
+  provider_url: string,
+  version: string,
+}
+
 const twitterCache = new NodeCache()
 
-async function getTweet(options: TwitterEmbedOptions): Promise<any> {
+async function getTweet(options: TwitterEmbedOptions): Promise<TwitterEmbedData> {
   const queryParams = new URLSearchParams({
     url: options.url,
     maxwidth: options.maxwidth!.toString(),
@@ -43,7 +57,7 @@ async function getTweet(options: TwitterEmbedOptions): Promise<any> {
   return await res.json()
 }
 
-export async function fetchTwitterEmbed(options: TwitterEmbedOptions): Promise<any> {
+export async function fetchTwitterEmbed(options: TwitterEmbedOptions): Promise<TwitterEmbedData | null> {
   const finalOptions = { ...DEFAULT_OPTIONS, ...options }
   const optsString = JSON.stringify(finalOptions)
   try {
@@ -54,7 +68,7 @@ export async function fetchTwitterEmbed(options: TwitterEmbedOptions): Promise<a
       data = await getTweet(finalOptions)
       twitterCache.set(optsString, data, data.cache_age)
     }
-    return data
+    return data as TwitterEmbedData
   } catch (exception) {
     console.error(exception)
     return null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       next-sitemap:
         specifier: ^4.2.3
         version: 4.2.3(next@15.3.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))
+      node-cache:
+        specifier: ^5.1.2
+        version: 5.1.2
       payload:
         specifier: 3.46.0
         version: 3.46.0(graphql@16.11.0)(typescript@5.7.3)
@@ -3840,6 +3843,10 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -5739,6 +5746,10 @@ packages:
 
   node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+
+  node-cache@5.1.2:
+    resolution: {integrity: sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==}
+    engines: {node: '>= 8.0.0'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -12317,6 +12328,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  clone@2.1.2: {}
+
   clsx@2.1.1: {}
 
   color-convert@1.9.3:
@@ -14542,6 +14555,10 @@ snapshots:
       semver: 7.7.2
 
   node-addon-api@6.1.0: {}
+
+  node-cache@5.1.2:
+    dependencies:
+      clone: 2.1.2
 
   node-domexception@1.0.0: {}
 


### PR DESCRIPTION
Adds a block for embedding tweets in an article.
* Supports all X oEmbed API options
* Respects light/dark theme
* Caches results using node-cache
<img width="772" height="485" alt="image" src="https://github.com/user-attachments/assets/85097d09-9b8f-491d-bb08-fe6c21f01a30" />
<img width="570" height="489" alt="image" src="https://github.com/user-attachments/assets/ed14f176-5d80-4d39-96e4-56d37063d44f" />
