### PR TITLE
add precticable port numbers to applications

### DIFF
--- a/apps/dgg-political-action/package.json
+++ b/apps/dgg-political-action/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
     "postbuild": "next-sitemap --config next-sitemap.config.cjs",
-    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
+    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev --port 3001",
     "dev:prod": "cross-env NODE_OPTIONS=--no-deprecation rm -rf .next && pnpm build && pnpm start",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
     "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",

--- a/apps/discord-bot/config/config.json
+++ b/apps/discord-bot/config/config.json
@@ -27,7 +27,7 @@
     }
   },
   "api": {
-    "port": 3001,
+    "port": 3002,
     "// NOTE: secret is now managed via environment variables": ""
   },
   "sharding": {

--- a/apps/pragmatic-papers/package.json
+++ b/apps/pragmatic-papers/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--no-deprecation next build",
     "postbuild": "next-sitemap --config next-sitemap.config.cjs",
-    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev --turbo",
+    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev --turbo --port 3000",
     "dev:prod": "cross-env NODE_OPTIONS=--no-deprecation rm -rf .next && pnpm build && pnpm start",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
     "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",


### PR DESCRIPTION
just adds port flags to the dev commands so testing is more predictable and we can use that for getting a consistent local URL in dev environments.