### PR TITLE
redeploy bot

### DIFF
--- a/apps/discord-bot/src/triggers/cta-post.ts
+++ b/apps/discord-bot/src/triggers/cta-post.ts
@@ -37,7 +37,7 @@ export class CTAPostTrigger implements Trigger {
   }
 
   public async execute(msg: Message): Promise<void> {
-    Logger.info(`execute() [START]: ${msg.id}`)
+    Logger.info(`execute() [START]: ${msg.id} `)
     if (msg === undefined) {
       return
     }


### PR DESCRIPTION
Permissions were needed to allow the bot to have access to the CTA channel.