### PR TITLE
Add nixpacks config for pragmatic-papers to be used on Coolify

### DIFF
--- a/apps/pragmatic-papers/nixpacks.toml
+++ b/apps/pragmatic-papers/nixpacks.toml
@@ -1,0 +1,12 @@
+[phases.setup]
+nixPkgs = ['pnpm']
+aptPkgs = ['build-essential']
+
+[phases.install]
+cmds = ["pnpm install --frozen-lockfile --prod"]
+
+[phases.build]
+cmds = ["pnpm build"]
+
+[start]
+cmd = "pnpm start"


### PR DESCRIPTION
Adds nixpacks configuration for use with building the application on Coolify

Currently setting up a staging instance to test out coolify before migrating from vercel

Based off example: https://github.com/coollabsio/coolify-examples/blob/v4.x/nextjs/ssr/nixpacks.toml