### PR TITLE
Fix header nav being inline with the logo rather than beneath it

### DIFF
--- a/apps/pragmatic-papers/src/Header/Component.client.tsx
+++ b/apps/pragmatic-papers/src/Header/Component.client.tsx
@@ -37,11 +37,11 @@ export const HeaderClient: React.FC<HeaderClientProps> = ({ data }) => {
       {...(theme ? { 'data-theme': theme } : {})}
     >
       <div className="hidden lg:block" />
-      <div className="flex justify-center md:col-span-2 lg:col-span-1">
-        <Link href="/">
+      <div className="flex flex-col justify-center md:col-span-2 lg:col-span-1">
+        <Link href="/" className="flex justify-center">
           <Logo loading="eager" priority="high" />
         </Link>
-        <div className={cn('flex justify-between', !data.navItems ? 'py-8' : '')}>
+        <div className={cn('flex justify-center', data.navItems ? 'pt-8' : '')}>
           <HeaderNav data={data} />
         </div>
       </div>


### PR DESCRIPTION
## Context

<!-- Why does this PR exist? What is it fixing? What is it trying to improve? How does it do so? -->

A bug slipped through my review of #267 since I didn't have header nav items at the time, the header nav should be beneath the logo, not inline with it.

<img width="746" height="532" alt="image" src="https://github.com/user-attachments/assets/bf02fab1-5d73-4264-9659-ef9347c5cfc4" />

<img width="746" height="532" alt="image" src="https://github.com/user-attachments/assets/ded44141-a964-437c-9272-c643011fc191" />

## Test Plan

<!-- How can someone test to ensure that your PR does what you say it does? -->

Go to header > Add nav items

Head to home page, see that header nav is beneath logo, centered, rather than inline with it