### PR TITLE
feat(pragmatic-papers): Add Iceout redirect

### DIFF
--- a/apps/pragmatic-papers/redirects.js
+++ b/apps/pragmatic-papers/redirects.js
@@ -13,7 +13,7 @@ const redirects = async () => {
   }
 
   const iceoutRedirect = {
-    source: '/iceout/:state',
+    source: '/iceout/:state*',
     destination: 'https://iceout.org/en/location/report',
     permanent: false,
   }


### PR DESCRIPTION
## Context

We are creating stickers that will direct users to Iceout's report page. This code sets up a redirect from our site so we can have multiple QR codes generated with different state suffixes and not have to remake all these stickers in case their site changes their structure.

## Test Plan

1) Navigate to https://www.pragmaticpapers.com/iceout/mn
1a) You will be redirected to https://iceout.org/en/location/report
