### PR TITLE
Discord Bot Webhook Listener

### DIFF
--- a/apps/discord-bot/src/models/bot.ts
+++ b/apps/discord-bot/src/models/bot.ts
@@ -28,6 +28,7 @@ import {
 import { type JobService, Logger } from '../services/index.js'
 import { PartialUtils } from '../utils/index.js'
 import { CTAPostTrigger } from '../triggers/cta-post.js'
+import { type WebhookService } from '../services/webhook-service.js'
 
 const require = createRequire(import.meta.url)
 const Config = require('../../config/config.json')
@@ -49,6 +50,7 @@ export class Bot {
     private buttonHandler: ButtonHandler,
     private reactionHandler: ReactionHandler,
     private jobService: JobService,
+    private webhookService: WebhookService,
   ) {}
 
   public async start(): Promise<void> {
@@ -91,6 +93,7 @@ export class Bot {
 
     if (!Debug.dummyMode.enabled) {
       this.jobService.start()
+      this.webhookService.start()
     }
 
     this.ready = true

--- a/apps/discord-bot/src/services/webhook-service.ts
+++ b/apps/discord-bot/src/services/webhook-service.ts
@@ -1,0 +1,25 @@
+import express, { type Express } from 'express'
+
+import { type Webhook } from '../webhooks/webhook.js'
+import { type Client } from 'discord.js'
+
+export class WebhookService {
+  private app: Express
+  constructor(
+    private webhooks: Webhook[],
+    private client: Client,
+  ) {}
+
+  public start(): void {
+    this.app = express()
+    this.app.use(express.json())
+    for (const webhook of this.webhooks) {
+      this.app.post(webhook.endpoint, async (req, res) => {
+        await webhook.run(req, res, this.client)
+        res.status(200).send('')
+      })
+    }
+    // TODO: We Figure out ports and stuff here
+    this.app.listen(3000)
+  }
+}

--- a/apps/discord-bot/src/start-bot.ts
+++ b/apps/discord-bot/src/start-bot.ts
@@ -41,6 +41,9 @@ import {
 } from './services/index.js'
 import { type Trigger } from './triggers/index.js'
 import { CTAPostTrigger } from './triggers/cta-post.js'
+import { WebhookService } from './services/webhook-service.js'
+import { type Webhook } from './webhooks/webhook.js';
+import { PragmaticPapersWebhook } from './webhooks/pragmatic-papers.js'
 
 const require = createRequire(import.meta.url)
 const Config = require('../config/config.json')
@@ -111,6 +114,8 @@ async function start(): Promise<void> {
     // TODO: Add new jobs here
   ]
 
+  const webhooks: Webhook[] = [new PragmaticPapersWebhook()]
+
   // Bot
   const bot = new Bot(
     process.env.DISCORD_BOT_TOKEN,
@@ -122,6 +127,7 @@ async function start(): Promise<void> {
     buttonHandler,
     reactionHandler,
     new JobService(jobs),
+    new WebhookService(webhooks, client),
   )
 
   // Register

--- a/apps/discord-bot/src/webhooks/pragmatic-papers.ts
+++ b/apps/discord-bot/src/webhooks/pragmatic-papers.ts
@@ -1,0 +1,40 @@
+import { type Client, EmbedBuilder } from 'discord.js'
+import { type Request, type Response } from 'express'
+
+import { Webhook } from './webhook.js';
+
+
+export class PragmaticPapersWebhook extends Webhook {
+  public name = 'Pragmatic Papers'
+  public log: boolean = true
+  public override endpoint: string = '/pragmatic-papers'
+
+  public async run(req: Request, res: Response, client: Client): Promise<void> {
+    const ppVolumeData = req.body;
+
+    // Generate the Volume URL
+    const volumeUrl = `https://pragmaticpapers.com/volumes/${ppVolumeData.volumeNumber}`
+
+    // Format the article list into a single string of links
+    const articleList = ppVolumeData.articles
+      .map((art) => `• [${art.name}](https://pragmaticpapers.com/articles/${art.slug})`)
+      .join('\n')
+
+    const embed = new EmbedBuilder()
+      .setColor('#1A1A1A') // Deep dark grey to match the image background
+      .setTitle(`Pragmatic Papers: Volume ${ppVolumeData.volumeNumber}`)
+      .setURL(volumeUrl)
+      .setAuthor({
+        name: 'Pragmatic Papers',
+        iconURL: 'https://pragmaticpapers.com/favicon-32x32.png',
+        url: 'https://pragmaticpapers.com',
+      })
+      .addFields({ name: 'Articles in this Volume', value: articleList })
+      .setTimestamp()
+
+    const channel = client.channels.cache.get('1084243505230127236')
+    if (channel?.isTextBased() && !channel.isDMBased()) {
+      await channel.send({ embeds: [embed] })
+    }
+  }
+}

--- a/apps/discord-bot/src/webhooks/webhook.ts
+++ b/apps/discord-bot/src/webhooks/webhook.ts
@@ -1,0 +1,9 @@
+import { type Request, type Response } from 'express'
+import { type Client } from 'discord.js'
+
+export abstract class Webhook {
+  abstract name: string
+  abstract log: boolean
+  abstract endpoint: string
+  abstract run(req: Request, res: Response, client: Client): Promise<void>
+}

--- a/apps/discord-bot/tests/scripts/test-webhook.sh
+++ b/apps/discord-bot/tests/scripts/test-webhook.sh
@@ -1,0 +1,14 @@
+curl http://localhost:3000/pragmatic-papers \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "volumeNumber": 1,
+    "articles": [
+      {"name": "Getting Away With It", "slug": "getting-away-with-it"},
+      {"name": "2016 Russian Interference Timeline", "slug": "2016-russian-interference-timeline"},
+      {"name": "America’s White Power Movement (1975–1995)", "slug": "america-s-white-power-movement-19751995"},
+      {"name": "The Venezuelan Response", "slug": "the-venezuelan-response"},
+      {"name": "Executive Order Monthly Report - November", "slug": "executive-order-monthly-report---november"},
+      {"name": "DGG Political Action Award - November Winner", "slug": "dgg-political-action-award---november-winner"}
+    ]
+  }'


### PR DESCRIPTION
## Summary

Introduces a **Webhook Service** powered by Express to allow the Discord bot to receive external HTTP POST requests.

### Key Changes

* **New `WebhookService`**: Orchestrates incoming requests and routes them to specific handlers.
* **Pragmatic Papers Integration**: A new webhook endpoint (`/pragmatic-papers`) that automatically posts formatted embeds to Discord when new volumes/articles are published.
* **Extensible Architecture**: Added a `Webhook` base class to easily plug in future external integrations.
* **Testing**: Included a shell script to simulate incoming webhook payloads locally.

### Technical Note

The service currently runs on port `3000` and maps incoming JSON data to Discord Embeds.

We need to figure out:
* Auth
* Should this be the port?
* Is this the real shape of the incoming data