### PR TITLE
Fix Preview Updates for Math Blocks

### DIFF
--- a/apps/pragmatic-papers/src/blocks/Math/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/Math/Component.tsx
@@ -26,10 +26,10 @@ export const MathBlock: React.FC<MathBlockProps> = (props) => {
     <>
       {isClient ? (
         isInline ? (
-          <MathJax inline>\({math}\)</MathJax>
+          <MathJax key={math} inline>\({math}\)</MathJax>
         ) : (
           <div className="my-4 flex justify-center">
-            <MathJax>\[{math}\]</MathJax>
+            <MathJax key={math}>\[{math}\]</MathJax>
           </div>
         )
       ) : null}


### PR DESCRIPTION
## Context

MathJax doesn't re-render once mounted even if the child math changes. Assigns a key to force a remount on change.

## Test Plan

Tested manually
