### PR TITLE
Add SEED_ENABLED flag and gate seeding endpoint

### DIFF
--- a/apps/pragmatic-papers/.env.example
+++ b/apps/pragmatic-papers/.env.example
@@ -18,3 +18,6 @@ PREVIEW_SECRET=YOUR_SECRET_HERE
 
 # Used to configure whether to use local storage or S3 storage
 USE_LOCAL_STORAGE=true
+
+# Set to "true" to allow database seeding. Enable on dev and staging; leave unset (or "false") in production.
+SEED_ENABLED=true

--- a/apps/pragmatic-papers/src/app/(frontend)/next/seed/route.ts
+++ b/apps/pragmatic-papers/src/app/(frontend)/next/seed/route.ts
@@ -1,15 +1,16 @@
+import { isAdmin } from '@/access/checkRole'
+import { seed } from '@/endpoints/seed'
+import type { User } from '@/payload-types'
+import configPromise from '@payload-config'
 import { NextResponse, type NextRequest } from 'next/server'
 import type { PayloadRequest } from 'payload'
 import { getPayload } from 'payload'
-import { seed } from '@/endpoints/seed'
-import { isAdmin } from '@/access/checkRole'
-import type { User } from '@/payload-types'
-import configPromise from '@payload-config'
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
-    if (process.env.NODE_ENV === 'production') {
-      return NextResponse.json({ error: 'Seeding is not allowed in production' }, { status: 403 })
+    // Seeding is reachable by endpoint on dev and staging; leave unset (or "false") in production.
+    if (process.env.SEED_ENABLED !== 'true') {
+      return NextResponse.json({ error: 'Seeding is not enabled in this environment' }, { status: 403 })
     }
 
     const payload = await getPayload({ config: configPromise })

--- a/apps/pragmatic-papers/src/components/BeforeDashboard/index.tsx
+++ b/apps/pragmatic-papers/src/components/BeforeDashboard/index.tsx
@@ -7,8 +7,7 @@ import './index.scss'
 const baseClass = 'before-dashboard'
 
 const BeforeDashboard: React.FC = () => {
-  // These are dev instructions, so we don't want to show them in production but feel free to make a component
-  // for the production dashboard if you want to show something different.
+  // Seeding ui is only visible on dev. Staging seeding is only reachable by endpoint.
   if (process.env.NODE_ENV === 'production') {
     return null
   }

--- a/apps/pragmatic-papers/src/environment.d.ts
+++ b/apps/pragmatic-papers/src/environment.d.ts
@@ -6,10 +6,12 @@ declare global {
       NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: string
       NEXT_PUBLIC_SERVER_URL: string
       VERCEL_PROJECT_PRODUCTION_URL: string
+      SEED_ENABLED?: 'true' | 'false'
     }
   }
 }
 
 // If this file has no import/export statements (i.e. is a script)
 // convert it into a module by adding an empty export statement.
-export {}
+export { }
+

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,8 @@
         "CRON_SECRET",
         "NEXT_PUBLIC_GOOGLE_ANALYTICS_ID",
         "NEXT_PUBLIC_SERVER_URL",
-        "NEXT_PUBLIC_SUPABASE_URL"
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "SEED_ENABLED"
       ]
     },
     "lint": {
@@ -76,7 +77,8 @@
         "CRON_SECRET",
         "NEXT_PUBLIC_GOOGLE_ANALYTICS_ID",
         "NEXT_PUBLIC_SERVER_URL",
-        "NEXT_PUBLIC_SUPABASE_URL"
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "SEED_ENABLED"
       ]
     }
   }


### PR DESCRIPTION
Introduce a SEED_ENABLED env flag and use it to control database seeding. Updates:

- .env.example: add SEED_ENABLED=true and a comment explaining intended usage (dev/staging only).
- seed route: replace NODE_ENV check with SEED_ENABLED !== 'true' to allow seeding when explicitly enabled; also reorder imports.
- environment.d.ts: add SEED_ENABLED to typed process.env and normalize empty export formatting.
- turbo.json: include SEED_ENABLED in the list of exposed environment variables for relevant tasks.
- BeforeDashboard: update comment to reflect that the seeding UI is only visible in dev while staging is reachable via the endpoint.

These changes allow explicit, environment-driven enabling of seeding rather than relying on NODE_ENV, and ensure CI/dev tooling and types are aware of the new flag.
