### PR TITLE
Page Level Caching

### DIFF
--- a/apps/pragmatic-papers/next.config.js
+++ b/apps/pragmatic-papers/next.config.js
@@ -47,11 +47,11 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=600, stale-while-revalidate=3600',
+            value: 'public, s-maxage=600, stale-while-revalidate=86400',
           },
           {
             key: 'CDN-Cache-Control',
-            value: 'max-age=600, stale-while-revalidate=3600',
+            value: 'max-age=600, stale-while-revalidate=86400',
           },
         ],
         missing: [

--- a/apps/pragmatic-papers/next.config.js
+++ b/apps/pragmatic-papers/next.config.js
@@ -27,6 +27,29 @@ const nextConfig = {
   },
   reactStrictMode: true,
   redirects,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=3600, stale-while-revalidate=86400',
+          },
+          {
+            key: 'CDN-Cache-Control',
+            value: 'max-age=3600, stale-while-revalidate=86400',
+          },
+        ],
+        missing: [
+          {
+            type: 'cookie',
+            key: '__prerender_bypass',
+          },
+        ],
+      },
+    ]
+  },
   turbopack: {
     resolveExtensions: ['.mdx', '.tsx', '.ts', '.jsx', '.js', '.mjs', '.json'],
     rules: {

--- a/apps/pragmatic-papers/next.config.js
+++ b/apps/pragmatic-papers/next.config.js
@@ -47,11 +47,11 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=3600, stale-while-revalidate=86400',
+            value: 'public, s-maxage=600, stale-while-revalidate=3600',
           },
           {
             key: 'CDN-Cache-Control',
-            value: 'max-age=3600, stale-while-revalidate=86400',
+            value: 'max-age=600, stale-while-revalidate=3600',
           },
         ],
         missing: [

--- a/apps/pragmatic-papers/next.config.js
+++ b/apps/pragmatic-papers/next.config.js
@@ -30,6 +30,19 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '/admin/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'private, no-cache, no-store, must-revalidate',
+          },
+          {
+            key: 'CDN-Cache-Control',
+            value: 'no-store',
+          },
+        ],
+      },
+      {
         source: '/:path*',
         headers: [
           {

--- a/apps/pragmatic-papers/src/app/(frontend)/layout.tsx
+++ b/apps/pragmatic-papers/src/app/(frontend)/layout.tsx
@@ -17,12 +17,10 @@ import './globals.css'
 const sourceSerif4 = Source_Serif_4({
   variable: '--font-serif',
   subsets: ['latin'],
-  display: 'swap',
 })
 
 const openSans = Open_Sans({
   subsets: ['latin'],
-  display: 'swap',
 })
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/apps/pragmatic-papers/src/app/(frontend)/layout.tsx
+++ b/apps/pragmatic-papers/src/app/(frontend)/layout.tsx
@@ -17,10 +17,12 @@ import './globals.css'
 const sourceSerif4 = Source_Serif_4({
   variable: '--font-serif',
   subsets: ['latin'],
+  display: 'swap',
 })
 
 const openSans = Open_Sans({
   subsets: ['latin'],
+  display: 'swap',
 })
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/apps/pragmatic-papers/src/components/VolumesView/entry.tsx
+++ b/apps/pragmatic-papers/src/components/VolumesView/entry.tsx
@@ -1,6 +1,4 @@
-'use client'
 import { cn } from '@/utilities/ui'
-import useClickableCard from '@/utilities/useClickableCard'
 import Link from 'next/link'
 import React from 'react'
 
@@ -10,8 +8,6 @@ import { formatWithOptions } from 'date-fns/fp'
 import { enUS } from 'date-fns/locale'
 
 import { toRoman } from '@/utilities/toRoman'
-
-// import { Media } from '@/components/Media'
 
 export type EntryVolumeData = Pick<
   Volume,
@@ -25,7 +21,6 @@ export const Entry: React.FC<{
   relationTo?: 'volumes'
   title?: string
 }> = (props) => {
-  const { card: entry, link } = useClickableCard({})
   const { className, doc, relationTo, title: titleFromProps } = props
 
   const { slug, description, title, volumeNumber, publishedAt } = doc || {}
@@ -37,7 +32,7 @@ export const Entry: React.FC<{
   const dateToString = formatWithOptions({ locale: enUS }, 'MMMM dd')
 
   return (
-    <article className={cn('overflow-hidden hover:cursor-pointer', className)} ref={entry.ref}>
+    <article className={cn('relative overflow-hidden hover:cursor-pointer', className)}>
       <div className="group">
         <div className="text-left text-sm">
           <span className="pe-2">Volume {toRoman(volumeNumber ?? 1)}</span>
@@ -48,9 +43,8 @@ export const Entry: React.FC<{
         {titleToUse && (
           <h3 className="my-6 text-center">
             <Link
-              className="text-xl font-bold transition-colors group-hover:text-brand md:text-3xl"
+              className="text-xl font-bold transition-colors group-hover:text-brand after:absolute after:inset-0 md:text-3xl"
               href={href}
-              ref={link.ref}
             >
               {titleToUse}
             </Link>


### PR DESCRIPTION
## Context

Makes HTML pages and js eligible for caching within Cloudflare's CDN. Cloudflare will async check for new content after ten minutes. 

This change nets us a ~350 ms reduction in network load time for a user in California. With First Contentful Paint decreasing by 0.3 seconds. 

Largest Contentful Paint is still quite bad due to some shift with the volume text (I'm suspicious of the fonts, still, I changed the clickable card to a css based approach).

<img width="1594" height="1070" alt="Screenshot 2026-03-10 at 10 14 10 PM" src="https://github.com/user-attachments/assets/b8955425-19e3-48b7-a82c-034568e8a863" />
<img width="1906" height="1012" alt="Screenshot 2026-03-10 at 10 14 18 PM" src="https://github.com/user-attachments/assets/19c72b6a-6c15-435d-9b0a-20dfa5859fa7" />
<img width="723" height="205" alt="Screenshot 2026-03-10 at 10 19 04 PM" src="https://github.com/user-attachments/assets/6019348a-9061-4582-be7e-95c713f5a8c2" />
<img width="781" height="204" alt="Screenshot 2026-03-10 at 10 19 12 PM" src="https://github.com/user-attachments/assets/06ea7675-721c-4ae6-be78-20b0f229fb40" />


Follow ups
- Set up a webhook on validation changes to alert cloudflare to re-fetch the page. I've punted on this because we have enough traffic that it will get refreshed fairly often.

## Test Plan

- [x] Test on the deployment environment
