### PR TITLE
add overide access: draft to queryTopicBySlug, queryArticlesByTopic

### DIFF
--- a/apps/pragmatic-papers/src/app/(frontend)/topics/[slug]/page.tsx
+++ b/apps/pragmatic-papers/src/app/(frontend)/topics/[slug]/page.tsx
@@ -46,6 +46,7 @@ const queryTopicBySlug = cache(async (slug: string): Promise<Topic | null> => {
     collection: "topics",
     draft,
     limit: 1,
+    overrideAccess: draft,
     pagination: false,
     where: {
       slug: {
@@ -69,6 +70,7 @@ const queryArticlesByTopic = cache(async (topicId: number, page: number = 1) => 
     draft,
     limit: ARTICLES_PER_PAGE,
     page,
+    overrideAccess: draft,
     pagination: false,
     where: {
       topics: {


### PR DESCRIPTION
## Context

Currently we have some bug on production that is not replicated in staging. Cannot find a way to test this on staging. 


