### PR TITLE
Fix Drop Caps & Make Cross Browser

### DIFF
--- a/apps/pragmatic-papers/src/app/(frontend)/globals.css
+++ b/apps/pragmatic-papers/src/app/(frontend)/globals.css
@@ -168,8 +168,20 @@
 
 @utility drop-cap {
   & > p:first-child::first-letter {
-    initial-letter: 2;
-    margin-right: 0.25em;
+    float: left;
+    font-size: 3em;
+    line-height: 0.9;
+    margin-right: 0.05em;
     font-weight: bold;
+  }
+
+  @supports (initial-letter: 2) {
+    & > p:first-child::first-letter {
+      float: none;
+      font-size: revert;
+      line-height: revert;
+      initial-letter: 2;
+      margin-right: 0.15em;
+    }
   }
 }


### PR DESCRIPTION
## Context
 
Drop caps are jumping into tables when they shouldn't on Chrome. And don't display at all in other browsers.

## Test Plan

This is a direct fix.