### PR TITLE
Fix page content popping in after header load

### DIFF
--- a/apps/pragmatic-papers/src/app/(frontend)/[slug]/page.tsx
+++ b/apps/pragmatic-papers/src/app/(frontend)/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { homeStatic } from "@/endpoints/seed/home-static"
 import configPromise from "@payload-config"
 import { draftMode } from "next/headers"
 import { getPayload, type RequiredDataFromCollectionSlug } from "payload"
-import { cache, Suspense } from "react"
+import { cache } from "react"
 
 import { RenderBlocks } from "@/blocks/RenderBlocks"
 import { JsonLd } from "@/components/JsonLd"
@@ -115,9 +115,7 @@ export default async function Page({ params, searchParams }: Args): Promise<Reac
 
       <RenderHero {...hero} />
 
-      <Suspense key={url}>
-        <RenderBlocks blocks={layout} pageNumber={pageNumber} />
-      </Suspense>
+      <RenderBlocks blocks={layout} pageNumber={pageNumber} />
     </article>
   )
 }


### PR DESCRIPTION
## Summary
- Removed the fallback-less `<Suspense>` wrapper around `<RenderBlocks>` in the `[slug]/page.tsx` page template
- This was causing Next.js streaming SSR to send the header immediately and defer all block content to a later stream chunk, making it visually "pop in" after the header rendered
    - This causes layout shift as the scoll-bar pops in for long pages
    - Contributes about 200ms of render delay to the LCP element


## Test plan
- [ ] Load the home page and verify all content renders together with the header (no pop-in)
- [ ] Check other pages using the `[slug]` template (e.g. any CMS page) for the same fix
- [ ] Confirm no regressions in draft/preview mode