### PR TITLE
Back-merge v2.0.9 (#587)

### DIFF
--- a/apps/pragmatic-papers/package.json
+++ b/apps/pragmatic-papers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pragmatic-papers",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "The Pragmatic Papers",
   "license": "MIT",
   "type": "module",

--- a/apps/pragmatic-papers/src/collections/Articles/hooks/populateVolume.ts
+++ b/apps/pragmatic-papers/src/collections/Articles/hooks/populateVolume.ts
@@ -6,6 +6,7 @@ export const populateVolume: CollectionAfterReadHook<Article> = async ({
   req: { payload, context },
 }) => {
   if (context.skipAfterRead) return doc
+  if (!doc.id) return doc
   const result = await payload.find({
     collection: "volumes",
     where: { articles: { contains: doc.id } },


### PR DESCRIPTION
Articles not editable when doc id is unset due to populateVolumes not
handling it properly.