### PR TITLE
Refine line-clamping on Captions and CollectionTile

### DIFF
--- a/apps/pragmatic-papers/src/blocks/CollectionGrid/CollectionTile.tsx
+++ b/apps/pragmatic-papers/src/blocks/CollectionGrid/CollectionTile.tsx
@@ -112,7 +112,7 @@ export const CollectionTile: React.FC<CollectionTileProps> = ({
 
         {/* Description */}
         {meta?.description && (
-          <p className="text-primary mt-1 line-clamp-3 font-serif text-lg leading-tight">
+          <p className="text-primary mt-1 line-clamp-4 font-serif text-base leading-tight">
             {meta!.description}
           </p>
         )}

--- a/apps/pragmatic-papers/src/blocks/Footnote/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/Footnote/Component.tsx
@@ -19,7 +19,7 @@ export const FootnoteBlock: React.FC<FootnoteBlockProps> = ({ note, index, class
       title={`Footnote ${index}: ${note}`}
     >
       <a
-        className="text-brand dark:text-brand-high-contrast font-semibold underline-offset-6 hover:underline"
+        className="text-brand/80 hover:text-brand dark:text-brand-high-contrast font-semibold underline-offset-6 hover:underline"
         href={`#${describedById}`}
         aria-describedby={describedById}
       >

--- a/apps/pragmatic-papers/src/blocks/Footnote/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/Footnote/Component.tsx
@@ -19,7 +19,7 @@ export const FootnoteBlock: React.FC<FootnoteBlockProps> = ({ note, index, class
       title={`Footnote ${index}: ${note}`}
     >
       <a
-        className="text-brand/80 hover:text-brand dark:text-brand-high-contrast font-semibold underline-offset-6 hover:underline"
+        className="text-brand dark:text-brand-high-contrast font-semibold underline-offset-6 hover:underline"
         href={`#${describedById}`}
         aria-describedby={describedById}
       >

--- a/apps/pragmatic-papers/src/blocks/MediaBlock/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaBlock/Component.tsx
@@ -85,7 +85,13 @@ export const MediaBlock: React.FC<StyledMediaBlockProps> = ({ sizes, ...props })
         className,
       )}
     >
-      <Media className={cn("border", imgClassName)} style={imgStyle} media={media} sizes={sizes} variant={variant} />
+      <Media
+        className={cn("border", imgClassName)}
+        style={imgStyle}
+        media={media}
+        sizes={sizes}
+        variant={variant}
+      />
       {caption && (
         <figcaption
           className={cn(

--- a/apps/pragmatic-papers/src/blocks/MediaBlock/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaBlock/Component.tsx
@@ -87,7 +87,7 @@ export const MediaBlock: React.FC<StyledMediaBlockProps> = ({ sizes, ...props })
       {caption && (
         <figcaption
           className={cn(
-            "text-primary my-1.5 line-clamp-1 text-center font-serif",
+            "text-primary my-1.5 text-center font-serif",
             {
               container: !disableInnerContainer,
             },

--- a/apps/pragmatic-papers/src/blocks/MediaBlock/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaBlock/Component.tsx
@@ -16,6 +16,7 @@ export type StyledMediaBlockProps = Omit<MediaBlockProps, "blockType"> & {
   breakout?: boolean
   className?: string
   imgClassName?: string
+  imgStyle?: React.CSSProperties
   captionClassName?: string
   enableGutter?: boolean
   sizes?: string | undefined
@@ -62,6 +63,7 @@ export const MediaBlock: React.FC<StyledMediaBlockProps> = ({ sizes, ...props })
     className,
     enableGutter = true,
     imgClassName,
+    imgStyle,
     media,
     variant = "medium",
     disableInnerContainer,
@@ -83,7 +85,7 @@ export const MediaBlock: React.FC<StyledMediaBlockProps> = ({ sizes, ...props })
         className,
       )}
     >
-      <Media className={cn("border", imgClassName)} media={media} sizes={sizes} variant={variant} />
+      <Media className={cn("border", imgClassName)} style={imgStyle} media={media} sizes={sizes} variant={variant} />
       {caption && (
         <figcaption
           className={cn(

--- a/apps/pragmatic-papers/src/blocks/MediaBlock/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaBlock/Component.tsx
@@ -87,7 +87,7 @@ export const MediaBlock: React.FC<StyledMediaBlockProps> = ({ sizes, ...props })
       {caption && (
         <figcaption
           className={cn(
-            "text-primary my-1.5 text-center font-serif",
+            "my-1.5 text-start font-serif leading-tight",
             {
               container: !disableInnerContainer,
             },

--- a/apps/pragmatic-papers/src/blocks/MediaBlock/LightboxMediaBlock.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaBlock/LightboxMediaBlock.tsx
@@ -32,7 +32,7 @@ export const LightboxMediaBlock: React.FC<LightboxMediaBlockProps> = ({
         />
       </DialogTrigger>
       <DialogContent
-        className="[&>button]:bg-background max-h-[90dvh] overflow-hidden p-0 text-base shadow-none ring-0 sm:max-w-max [&>button]:top-2 [&>button]:right-2 [&>button]:rounded-sm [&>button]:p-0.5 [&>button_svg]:size-6"
+        className="[&>button]:bg-background max-h-[90dvh] overflow-hidden rounded-none bg-transparent p-0 text-base shadow-none ring-0 sm:max-w-max [&>button]:top-2 [&>button]:right-2 [&>button]:rounded-sm [&>button]:p-0.5 [&>button_svg]:size-6"
         style={{
           maxWidth: `min(calc(100vw - 2rem), calc(80dvh * ${media.width ?? 1} / ${media.height ?? 1}))`,
         }}

--- a/apps/pragmatic-papers/src/blocks/MediaBlock/LightboxMediaBlock.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaBlock/LightboxMediaBlock.tsx
@@ -31,7 +31,12 @@ export const LightboxMediaBlock: React.FC<LightboxMediaBlockProps> = ({
           {...props}
         />
       </DialogTrigger>
-      <DialogContent className="[&>button]:bg-background max-h-[90dvh] overflow-hidden p-0 text-base shadow-none ring-0 sm:max-w-max [&>button]:top-2 [&>button]:right-2 [&>button]:rounded-sm [&>button]:p-0.5 [&>button_svg]:size-6">
+      <DialogContent
+        className="[&>button]:bg-background max-h-[90dvh] overflow-hidden p-0 text-base shadow-none ring-0 sm:max-w-max [&>button]:top-2 [&>button]:right-2 [&>button]:rounded-sm [&>button]:p-0.5 [&>button_svg]:size-6"
+        style={{
+          maxWidth: `min(calc(100vw - 2rem), calc(80dvh * ${media.width ?? 1} / ${media.height ?? 1}))`,
+        }}
+      >
         <DialogHeader className="sr-only">
           <DialogTitle>{media.filename}</DialogTitle>
         </DialogHeader>
@@ -41,7 +46,8 @@ export const LightboxMediaBlock: React.FC<LightboxMediaBlockProps> = ({
           variant="xlarge"
           enableGutter={false}
           className="text-muted-foreground [&_a]:text-foreground"
-          imgClassName="border max-h-[calc(90dvh-3.5rem)] w-auto"
+          imgClassName="border max-h-[80dvh] w-full h-auto"
+          captionClassName="max-h-24 overflow-y-auto px-4"
           disableInnerContainer
         />
       </DialogContent>

--- a/apps/pragmatic-papers/src/blocks/MediaBlock/LightboxMediaBlock.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaBlock/LightboxMediaBlock.tsx
@@ -23,7 +23,13 @@ export const LightboxMediaBlock: React.FC<LightboxMediaBlockProps> = ({
   return (
     <Dialog>
       <DialogTrigger className={cn("w-full", containerClassName)}>
-        <MediaBlock media={media} enableGutter={false} className={className} {...props} />
+        <MediaBlock
+          media={media}
+          enableGutter={false}
+          className={className}
+          disableInnerContainer
+          {...props}
+        />
       </DialogTrigger>
       <DialogContent className="[&>button]:bg-background max-h-[90dvh] overflow-hidden p-0 text-base shadow-none ring-0 sm:max-w-max [&>button]:top-2 [&>button]:right-2 [&>button]:rounded-sm [&>button]:p-0.5 [&>button_svg]:size-6">
         <DialogHeader className="sr-only">
@@ -34,7 +40,9 @@ export const LightboxMediaBlock: React.FC<LightboxMediaBlockProps> = ({
           sizes="100vw"
           variant="xlarge"
           enableGutter={false}
+          className="text-muted-foreground [&_a]:text-foreground"
           imgClassName="border max-h-[calc(90dvh-3.5rem)] w-auto"
+          disableInnerContainer
         />
       </DialogContent>
     </Dialog>

--- a/apps/pragmatic-papers/src/blocks/MediaCollageBlock/component.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaCollageBlock/component.tsx
@@ -30,7 +30,7 @@ export const MediaCollageBlock: React.FC<MediaCollageBlockType> = (props) => {
             key={`${id}-${idx}`}
             media={media}
             containerClassName={cn(isLastOddItem && "mx-auto md:col-span-2 w-1/2")}
-            className="not-prose my-0 [&>figcaption]:my-1.5"
+            className="my-0! [&>figcaption]:hidden"
             sizes="(max-width: 768px) 100vw, (max-width: 1376px) 50vw, 688px"
           />
         )

--- a/apps/pragmatic-papers/src/blocks/MediaCollageBlock/component.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaCollageBlock/component.tsx
@@ -30,7 +30,7 @@ export const MediaCollageBlock: React.FC<MediaCollageBlockType> = (props) => {
             key={`${id}-${idx}`}
             media={media}
             containerClassName={cn(isLastOddItem && "mx-auto md:col-span-2 w-1/2")}
-            className="my-0 [&>figcaption]:my-1.5"
+            className="not-prose my-0 [&>figcaption]:my-1.5"
             sizes="(max-width: 768px) 100vw, (max-width: 1376px) 50vw, 688px"
           />
         )

--- a/apps/pragmatic-papers/src/blocks/MediaCollageBlock/component.tsx
+++ b/apps/pragmatic-papers/src/blocks/MediaCollageBlock/component.tsx
@@ -30,7 +30,7 @@ export const MediaCollageBlock: React.FC<MediaCollageBlockType> = (props) => {
             key={`${id}-${idx}`}
             media={media}
             containerClassName={cn(isLastOddItem && "mx-auto md:col-span-2 w-1/2")}
-            className="not-prose"
+            className="my-0 [&>figcaption]:my-1.5"
             sizes="(max-width: 768px) 100vw, (max-width: 1376px) 50vw, 688px"
           />
         )

--- a/apps/pragmatic-papers/src/components/ArticleCard/index.tsx
+++ b/apps/pragmatic-papers/src/components/ArticleCard/index.tsx
@@ -34,14 +34,8 @@ export const ArticleCard: React.FC<{
             sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, 352px"
           />
         )}
-        {titleToUse && (
-          <h3 className="hover:text-primary/80 line-clamp-4 md:text-2xl">{titleToUse}</h3>
-        )}
-        {description && (
-          <p className="text-primary line-clamp-2 font-serif sm:line-clamp-3">
-            {sanitizedDescription}
-          </p>
-        )}
+        {titleToUse && <h3 className="hover:text-primary/80 md:text-2xl">{titleToUse}</h3>}
+        {description && <p className="text-primary font-serif">{sanitizedDescription}</p>}
       </div>
     </HoverPrefetchLink>
   )

--- a/apps/pragmatic-papers/src/endpoints/seed/features/media-collage.ts
+++ b/apps/pragmatic-papers/src/endpoints/seed/features/media-collage.ts
@@ -44,6 +44,16 @@ function createMediaCollageBlock(mediaIds: number[], layout: "grid" | "carousel"
   }
 }
 
+// Deliberately long caption to verify that the caption scrolls independently
+// without affecting the image area (tests overflow-y-auto on captionClassName).
+const LONG_CAPTION =
+  "This is a deliberately long caption to test the scrollable caption area in the lightbox. " +
+  "When a caption exceeds approximately four lines of text it should begin scrolling within its own " +
+  "container, leaving the image completely undisturbed above it. " +
+  "You are reading line three now — the scroll threshold should be approaching. " +
+  "Here is the fifth line, which should be hidden behind the scroll boundary and only visible " +
+  "after scrolling down within the caption area itself."
+
 export const createMediaCollageArticle = async (
   payload: Payload,
   writer: User,
@@ -51,36 +61,90 @@ export const createMediaCollageArticle = async (
   topics: number[] = [],
 ): Promise<number> => {
   // Create media with captions
-  const [itsBadMedia, blueCoatMedia] = await Promise.all([
-    createMediaFromURL(
-      payload,
-      "https://wikicdn.destiny.gg/f/fd/ITSBAD.png",
-      "It's bad, what do you want me to say!",
-      {
-        caption: createRichText([
-          createParagraph([
-            createTextNode("It's bad, what do you want me to say! "),
-            createLinkNode("Learn more", "https://destiny.gg", true),
+  const [itsBadMedia, blueCoatMedia, wideMedia, portraitMedia, longCaptionMedia] =
+    await Promise.all([
+      createMediaFromURL(
+        payload,
+        "https://wikicdn.destiny.gg/f/fd/ITSBAD.png",
+        "It's bad, what do you want me to say!",
+        {
+          caption: createRichText([
+            createParagraph([
+              createTextNode("It's bad, what do you want me to say! "),
+              createLinkNode("Learn more", "https://destiny.gg", true),
+            ]),
           ]),
-        ]),
-      },
-    ),
-    createMediaFromURL(
-      payload,
-      "https://wikicdn.destiny.gg/6/64/BlueCoat.jpg",
-      "A snazzy blue jacket",
-      {
-        caption: createRichTextFromString("A snazzy blue jacket"),
-      },
-    ),
-  ])
+        },
+      ),
+      createMediaFromURL(
+        payload,
+        "https://wikicdn.destiny.gg/6/64/BlueCoat.jpg",
+        "A snazzy blue jacket",
+        {
+          caption: createRichTextFromString("A snazzy blue jacket"),
+        },
+      ),
+      // Wide landscape (≈5:1) — tests max-w-[90vw] constraint (horizontal overflow fix)
+      createMediaFromURL(
+        payload,
+        "https://picsum.photos/seed/pp-wide/1920/400.jpg",
+        "A wide panoramic landscape",
+        {
+          caption: createRichTextFromString(
+            "Wide landscape: should never overflow the viewport horizontally.",
+          ),
+        },
+      ),
+      // Tall portrait (≈4:9) — tests max-h-[80dvh] constraint (vertical overflow fix)
+      createMediaFromURL(
+        payload,
+        "https://picsum.photos/seed/pp-portrait/400/900.jpg",
+        "A tall portrait image",
+        {
+          caption: createRichTextFromString("Tall portrait: should fit within the viewport height."),
+        },
+      ),
+      // Long caption — tests overflow-y-auto scrolling on the caption area
+      createMediaFromURL(
+        payload,
+        "https://picsum.photos/seed/pp-caption/800/600.jpg",
+        "An image with a very long caption",
+        {
+          caption: createRichTextFromString(LONG_CAPTION),
+        },
+      ),
+    ])
 
   // Build the article content programmatically
   const content = createRichText([
-    createParagraph("First, Click on an image to see a modal pop up. It displays captions!"),
+    // Short caption baseline
+    createParagraph("Click on any image to open the lightbox. Captions are shown below the image."),
     createMediaBlock(itsBadMedia.id),
     createEmptyParagraph(),
-    createParagraph("Try viewing a grid of images!"),
+    // Wide landscape — horizontal overflow regression test
+    createParagraph("Wide landscape image — the lightbox should constrain width to 90vw."),
+    createMediaBlock(wideMedia.id),
+    createEmptyParagraph(),
+    // Tall portrait — vertical overflow regression test
+    createParagraph("Tall portrait image — the lightbox should constrain height to 80dvh."),
+    createMediaBlock(portraitMedia.id),
+    createEmptyParagraph(),
+    // Long caption — caption scroll test
+    createParagraph(
+      "Image with a long caption — the caption scrolls independently; the image is unaffected.",
+    ),
+    createMediaBlock(longCaptionMedia.id),
+    createEmptyParagraph(),
+    // No caption — baseline (mediaDocs have no caption set)
+    ...(mediaDocs[0]
+      ? [
+          createParagraph("Image without a caption — no caption area should appear."),
+          createMediaBlock(mediaDocs[0].id),
+          createEmptyParagraph(),
+        ]
+      : []),
+    // Grid with mixed aspect ratios
+    createParagraph("Grid layout with a mix of aspect ratios."),
     createMediaCollageBlock(
       [mediaDocs[3]?.id, mediaDocs[0]?.id, mediaDocs[2]?.id, mediaDocs[1]?.id].filter(
         (id): id is number => id !== undefined,
@@ -88,7 +152,7 @@ export const createMediaCollageArticle = async (
       "grid",
     ),
     createEmptyParagraph(),
-    createParagraph("View them in a carousel! Click for modals!"),
+    createParagraph("Carousel — click any image for a lightbox modal."),
     createMediaCollageBlock(
       [mediaDocs[3]?.id, mediaDocs[0]?.id, mediaDocs[2]?.id].filter(
         (id): id is number => id !== undefined,
@@ -96,15 +160,15 @@ export const createMediaCollageArticle = async (
       "carousel",
     ),
     createEmptyParagraph(),
-    createParagraph("Mix and match! Carousel with different images!"),
+    createParagraph("Mixed carousel with wide, portrait, and captioned images."),
     createMediaCollageBlock(
-      [mediaDocs[1]?.id, blueCoatMedia.id, mediaDocs[2]?.id, itsBadMedia.id].filter(
+      [wideMedia.id, portraitMedia.id, blueCoatMedia.id, itsBadMedia.id].filter(
         (id): id is number => id !== undefined,
       ),
       "carousel",
     ),
     createEmptyParagraph(),
-    createParagraph("Another grid layout with differently shaped images!"),
+    createParagraph("Another grid layout with differently shaped images."),
     createMediaCollageBlock(
       [mediaDocs[0]?.id, itsBadMedia.id, blueCoatMedia.id].filter(
         (id): id is number => id !== undefined,

--- a/apps/pragmatic-papers/src/endpoints/seed/features/media-collage.ts
+++ b/apps/pragmatic-papers/src/endpoints/seed/features/media-collage.ts
@@ -3,7 +3,6 @@ import type { Payload } from "payload"
 import { createArticle } from "../articles"
 import { createMediaFromURL } from "../media"
 import {
-  createEmptyParagraph,
   createLinkNode,
   createParagraph,
   createRichText,
@@ -101,7 +100,9 @@ export const createMediaCollageArticle = async (
         "https://picsum.photos/seed/pp-portrait/400/900.jpg",
         "A tall portrait image",
         {
-          caption: createRichTextFromString("Tall portrait: should fit within the viewport height."),
+          caption: createRichTextFromString(
+            "Tall portrait: should fit within the viewport height.",
+          ),
         },
       ),
       // Long caption — tests overflow-y-auto scrolling on the caption area
@@ -120,27 +121,22 @@ export const createMediaCollageArticle = async (
     // Short caption baseline
     createParagraph("Click on any image to open the lightbox. Captions are shown below the image."),
     createMediaBlock(itsBadMedia.id),
-    createEmptyParagraph(),
     // Wide landscape — horizontal overflow regression test
     createParagraph("Wide landscape image — the lightbox should constrain width to 90vw."),
     createMediaBlock(wideMedia.id),
-    createEmptyParagraph(),
     // Tall portrait — vertical overflow regression test
     createParagraph("Tall portrait image — the lightbox should constrain height to 80dvh."),
     createMediaBlock(portraitMedia.id),
-    createEmptyParagraph(),
     // Long caption — caption scroll test
     createParagraph(
       "Image with a long caption — the caption scrolls independently; the image is unaffected.",
     ),
     createMediaBlock(longCaptionMedia.id),
-    createEmptyParagraph(),
     // No caption — baseline (mediaDocs have no caption set)
     ...(mediaDocs[0]
       ? [
           createParagraph("Image without a caption — no caption area should appear."),
           createMediaBlock(mediaDocs[0].id),
-          createEmptyParagraph(),
         ]
       : []),
     // Grid with mixed aspect ratios
@@ -151,7 +147,6 @@ export const createMediaCollageArticle = async (
       ),
       "grid",
     ),
-    createEmptyParagraph(),
     createParagraph("Carousel — click any image for a lightbox modal."),
     createMediaCollageBlock(
       [mediaDocs[3]?.id, mediaDocs[0]?.id, mediaDocs[2]?.id].filter(
@@ -159,7 +154,6 @@ export const createMediaCollageArticle = async (
       ),
       "carousel",
     ),
-    createEmptyParagraph(),
     createParagraph("Mixed carousel with wide, portrait, and captioned images."),
     createMediaCollageBlock(
       [wideMedia.id, portraitMedia.id, blueCoatMedia.id, itsBadMedia.id].filter(
@@ -167,7 +161,6 @@ export const createMediaCollageArticle = async (
       ),
       "carousel",
     ),
-    createEmptyParagraph(),
     createParagraph("Another grid layout with differently shaped images."),
     createMediaCollageBlock(
       [mediaDocs[0]?.id, itsBadMedia.id, blueCoatMedia.id].filter(

--- a/apps/pragmatic-papers/src/endpoints/seed/index.ts
+++ b/apps/pragmatic-papers/src/endpoints/seed/index.ts
@@ -135,7 +135,7 @@ export const seed = async (
             heroImage: ctx.media[i % ctx.media.length]?.id,
             meta: {
               title,
-              description: generateLoremIpsumParagraph(Math.floor(Math.random() * 2) + 1),
+              description: generateLoremIpsumParagraph(Math.floor(Math.random() * 2) + 1, 150),
               image: ctx.media[i % ctx.media.length]?.id,
             },
           })
@@ -164,7 +164,7 @@ export const seed = async (
             heroImage: ctx.media[i % ctx.media.length]?.id,
             meta: {
               title,
-              description: generateLoremIpsumParagraph(Math.floor(Math.random() * 2) + 1),
+              description: generateLoremIpsumParagraph(Math.floor(Math.random() * 2) + 1, 150),
               image: ctx.media[i % ctx.media.length]?.id,
             },
           })

--- a/apps/pragmatic-papers/src/endpoints/seed/index.ts
+++ b/apps/pragmatic-papers/src/endpoints/seed/index.ts
@@ -10,7 +10,7 @@ import { createLegacySocialEmbedArticle, createSocialEmbedArticle } from "./feat
 import { createMediaFromURL } from "./media"
 import { createMenus } from "./menus"
 import { createPages } from "./pages"
-import { createLoremIpsumContent, generateLoremIpsumParagraph } from "./richtext"
+import { createLoremIpsumContent, generateLoremIspumSentence } from "./richtext"
 import { createTopics } from "./topics"
 import { createUsers } from "./users"
 import { createVolumes } from "./volumes"
@@ -135,7 +135,7 @@ export const seed = async (
             heroImage: ctx.media[i % ctx.media.length]?.id,
             meta: {
               title,
-              description: generateLoremIpsumParagraph(Math.floor(Math.random() * 2) + 1, 150),
+              description: generateLoremIspumSentence(),
               image: ctx.media[i % ctx.media.length]?.id,
             },
           })
@@ -164,7 +164,7 @@ export const seed = async (
             heroImage: ctx.media[i % ctx.media.length]?.id,
             meta: {
               title,
-              description: generateLoremIpsumParagraph(Math.floor(Math.random() * 2) + 1, 150),
+              description: generateLoremIspumSentence(),
               image: ctx.media[i % ctx.media.length]?.id,
             },
           })

--- a/apps/pragmatic-papers/src/endpoints/seed/richtext.ts
+++ b/apps/pragmatic-papers/src/endpoints/seed/richtext.ts
@@ -178,8 +178,7 @@ const LOREM_IPSUMS = [
 ] as const
 
 /**
- * Generates a Lorem Ipsum sentence with a specified number of characters with terminating period inclusive.
- * Max Characters must be greater than zero.
+ * Generates a Lorem Ipsum sentence
  */
 export function generateLoremIspumSentence(): string {
   return LOREM_IPSUMS[Math.floor(Math.random() * LOREM_IPSUMS.length)]!

--- a/apps/pragmatic-papers/src/endpoints/seed/richtext.ts
+++ b/apps/pragmatic-papers/src/endpoints/seed/richtext.ts
@@ -181,27 +181,15 @@ const LOREM_IPSUMS = [
  * Generates a Lorem Ipsum sentence with a specified number of characters with terminating period inclusive.
  * Max Characters must be greater than zero.
  */
-export function generateLoremIspumSentence(maxCharacters?: number): string {
-  const sentence = LOREM_IPSUMS[Math.floor(Math.random() * LOREM_IPSUMS.length)]!
-  if (maxCharacters) {
-    return sentence
-      .slice(0, maxCharacters - 1)
-      .trimEnd()
-      .concat(".")
-  }
-  return sentence
+export function generateLoremIspumSentence(): string {
+  return LOREM_IPSUMS[Math.floor(Math.random() * LOREM_IPSUMS.length)]!
 }
 
 /**
  * Generates a Lorem Ipsum paragraph with a specified number of sentences
  */
-export function generateLoremIpsumParagraph(
-  numberOfSentences: number,
-  maxCharacters?: number,
-): string {
-  return Array.from({ length: numberOfSentences }, () => {
-    return generateLoremIspumSentence(maxCharacters)
-  }).join(" ")
+export function generateLoremIpsumParagraph(numberOfSentences: number): string {
+  return Array.from({ length: numberOfSentences }, () => generateLoremIspumSentence()).join(" ")
 }
 
 /**
@@ -210,10 +198,9 @@ export function generateLoremIpsumParagraph(
 export function generateLoremIpsumParagraphs(
   numberOfParagraphs: number,
   numberOfSentences = 5,
-  maxCharacters?: number,
 ): string[] {
   return Array.from({ length: numberOfParagraphs }, () =>
-    generateLoremIpsumParagraph(numberOfSentences, maxCharacters),
+    generateLoremIpsumParagraph(numberOfSentences),
   )
 }
 
@@ -223,13 +210,8 @@ export function generateLoremIpsumParagraphs(
 export function createLoremIpsumContent(
   numberOfParagraphs: number,
   numberOfSentences?: number,
-  maxCharacters?: number,
 ): LexicalContent {
-  const paragraphs = generateLoremIpsumParagraphs(
-    numberOfParagraphs,
-    numberOfSentences,
-    maxCharacters,
-  )
+  const paragraphs = generateLoremIpsumParagraphs(numberOfParagraphs, numberOfSentences)
   return createRichTextFromParagraphs(paragraphs, true)
 }
 

--- a/apps/pragmatic-papers/src/endpoints/seed/richtext.ts
+++ b/apps/pragmatic-papers/src/endpoints/seed/richtext.ts
@@ -175,29 +175,61 @@ const LOREM_IPSUMS = [
   "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
   "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur; yee wins.",
   "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-]
+] as const
+
+/**
+ * Generates a Lorem Ipsum sentence with a specified number of characters with terminating period inclusive.
+ * Max Characters must be greater than zero.
+ */
+export function generateLoremIspumSentence(maxCharacters?: number): string {
+  const sentence = LOREM_IPSUMS[Math.floor(Math.random() * LOREM_IPSUMS.length)]!
+  if (maxCharacters) {
+    return sentence
+      .slice(0, maxCharacters - 1)
+      .trimEnd()
+      .concat(".")
+  }
+  return sentence
+}
 
 /**
  * Generates a Lorem Ipsum paragraph with a specified number of sentences
  */
-export function generateLoremIpsumParagraph(numberOfSentences: number): string {
+export function generateLoremIpsumParagraph(
+  numberOfSentences: number,
+  maxCharacters?: number,
+): string {
   return Array.from({ length: numberOfSentences }, () => {
-    return LOREM_IPSUMS[Math.floor(Math.random() * LOREM_IPSUMS.length)]
+    return generateLoremIspumSentence(maxCharacters)
   }).join(" ")
 }
 
 /**
  * Generates an array of Lorem Ipsum paragraphs
  */
-export function generateLoremIpsumParagraphs(numberOfParagraphs: number): string[] {
-  return Array.from({ length: numberOfParagraphs }, () => generateLoremIpsumParagraph(5))
+export function generateLoremIpsumParagraphs(
+  numberOfParagraphs: number,
+  numberOfSentences = 5,
+  maxCharacters?: number,
+): string[] {
+  return Array.from({ length: numberOfParagraphs }, () =>
+    generateLoremIpsumParagraph(numberOfSentences, maxCharacters),
+  )
 }
 
 /**
  * Creates Lorem Ipsum rich text content with spacing between paragraphs
  */
-export function createLoremIpsumContent(numberOfParagraphs: number): LexicalContent {
-  const paragraphs = generateLoremIpsumParagraphs(numberOfParagraphs)
+export function createLoremIpsumContent(
+  numberOfParagraphs: number,
+  numberOfSentences?: number,
+  maxCharacters?: number,
+): LexicalContent {
+  const paragraphs = generateLoremIpsumParagraphs(
+    numberOfParagraphs,
+    numberOfSentences,
+    maxCharacters,
+  )
   return createRichTextFromParagraphs(paragraphs, true)
 }
 

--- a/apps/pragmatic-papers/src/endpoints/seed/volumes.ts
+++ b/apps/pragmatic-papers/src/endpoints/seed/volumes.ts
@@ -1,6 +1,6 @@
 import type { Media, Volume } from "@/payload-types"
-import { createRichTextFromString } from "./richtext"
 import type { Payload, RequiredDataFromCollectionSlug } from "payload"
+import { createRichTextFromString } from "./richtext"
 
 interface VolumeConfig {
   volumeNumber: number


### PR DESCRIPTION
## Context

Request for longer captions from Jacob.

line-clamp on captions & CollectionTile is too restrictive. 

CollectionTile: Our meta descriptions are under 150 chars and our line clamp is still cutting them off. Our font is 18px within tiles and only allows 3 lines of text. Noticing smaller font on homepage tiles and 4 lines of description on other sites like nytimes. 

Article Tile Description on other sides:

| site | font-size | line-height | ratio |
| --- | --- | --- | --- |
| nytimes | 16px | 19px |  1.1875 |
| atlantic | 18px | 26px | 1.444 |
| bbc | 14px | 18px | 1.2857 |
| cnn | 16px | 22px | 1.375 |
| prag | 18px | 22.5px | 1.25 |

- Unifying caption styling in article, masonry grid, and lightboxes.
- Increasing line clamp to 4 lines for Collection Tile descriptions. 
- Bringing CollectionTile description font-size in line with with other sites. (16px seems to be good middle ground)

## Test Plan

See https://pr-590.pragmaticpapers.com/articles/the-many-demonstrations-of-images