### PR TITLE
Shrink margins and contain separator

### DIFF
--- a/apps/pragmatic-papers/src/blocks/CollectionGrid/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/CollectionGrid/Component.tsx
@@ -38,12 +38,12 @@ export const CollectionGridBlock: React.FC<
     <>
       <LayoutComponent
         id={id ?? undefined}
-        className="container mb-10 items-stretch md:mb-20"
+        className="container mb-9 items-stretch md:mb-12"
         slots={slots}
         priority={priority}
         loading={priority ? "eager" : undefined}
       />
-      <div className="container mb-10 last-of-type:mb-10 md:mb-20">
+      <div className="container mb-9 md:mb-12">
         <Separator />
       </div>
     </>

--- a/apps/pragmatic-papers/src/blocks/CollectionGrid/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/CollectionGrid/Component.tsx
@@ -38,12 +38,14 @@ export const CollectionGridBlock: React.FC<
     <>
       <LayoutComponent
         id={id ?? undefined}
-        className="container mb-10 items-stretch md:mb-20 lg:mb-40"
+        className="container mb-10 items-stretch md:mb-20"
         slots={slots}
         priority={priority}
         loading={priority ? "eager" : undefined}
       />
-      <Separator className="container mx-auto mb-10 px-4 last-of-type:mb-10 md:mb-20 lg:mb-40" />
+      <div className="container mb-10 last-of-type:mb-10 md:mb-20">
+        <Separator />
+      </div>
     </>
   )
 }


### PR DESCRIPTION
## Context

Request from Cara: less empty space between collection grids. Capping vertical margins to 20px.

## Test Plan

- [ ] Go to home page and notice margins between collection grids are smaller.