### PR TITLE
Improve Footnote Light Theme Contrast

### DIFF
--- a/apps/pragmatic-papers/src/blocks/Footnote/Component.tsx
+++ b/apps/pragmatic-papers/src/blocks/Footnote/Component.tsx
@@ -19,7 +19,7 @@ export const FootnoteBlock: React.FC<FootnoteBlockProps> = ({ note, index, class
       title={`Footnote ${index}: ${note}`}
     >
       <a
-        className="text-brand/80 hover:text-brand dark:text-brand-high-contrast font-semibold underline-offset-6 hover:underline"
+        className="text-brand dark:text-brand-high-contrast font-semibold underline-offset-6 hover:underline"
         href={`#${describedById}`}
         aria-describedby={describedById}
       >


### PR DESCRIPTION
## Context

Footnote sup links are 80% opacity in lightmode. Low contrast. Removing. Hover state not necessary.

## Test Plan

- [ ] Notice how footnotes are no longer transparent in light mode.
