### PR TITLE
Fix Admin: Production Image Thumbnails Not Showing

### DIFF
--- a/src/collections/Media/index.ts
+++ b/src/collections/Media/index.ts
@@ -93,7 +93,8 @@ export const Media: CollectionConfig = {
   upload: {
     // Upload to the public/media directory in Next.js making them publicly accessible even outside of Payload
     staticDir: path.resolve(dirname, "../../../public/media"),
-    adminThumbnail: "thumbnail",
+    adminThumbnail: ({ doc }: { doc: Partial<MediaType> }) =>
+      doc.sizes?.thumbnail?.url || "thumbnail",
     formatOptions: {
       format: "webp",
     },


### PR DESCRIPTION
## Context
[Closes #533 ](https://github.com/digitalgroundgame/pragmatic-papers/issues/533)

reference: https://github.com/payloadcms/payload/issues/12659

## Test Plan
Ensure admin panel is not broken in staging.

Maybe enable s3 bucket in staging temporarily for testing?