### PR TITLE
restore migration command to docker build

### DIFF
--- a/dockerfiles/PragmaticPapers.Dockerfile
+++ b/dockerfiles/PragmaticPapers.Dockerfile
@@ -116,6 +116,7 @@ RUN /usr/local/bin/modify-database-uri.sh && \
 # Source the potentially modified DATABASE_URI before building
 RUN . /tmp/build.env && \
     pnpm install --frozen-lockfile && \
+    pnpm payload migrate && \
     pnpm build
 
 # ============================================


### PR DESCRIPTION
## Context
removing turbo commands, payload migrate was removed from the build process.
adding back payload migrate command.

## Test Plan
see if dockerfile build logs run migrate command.
