### PR TITLE
Footnote Label Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "feed": "^5.1.0",
     "geist": "^1.7.0",
     "graphql": "^16.12.0",
+    "lexical": "0.41.0",
+    "@lexical/react": "0.41.0",
     "lucide-react": "^0.577.0",
     "next": "~15.4.11",
     "next-sitemap": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,6 @@
     "feed": "^5.1.0",
     "geist": "^1.7.0",
     "graphql": "^16.12.0",
-    "lexical": "0.41.0",
-    "@lexical/react": "0.41.0",
     "lucide-react": "^0.577.0",
     "next": "~15.4.11",
     "next-sitemap": "^4.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.2.0
         version: 1.3.0(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@lexical/react':
+        specifier: 0.41.0
+        version: 0.41.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(yjs@13.6.28)
       '@next/third-parties':
         specifier: ^15.3.6
         version: 15.3.6(next@15.4.11(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))(react@19.2.3)
@@ -77,6 +80,9 @@ importers:
       graphql:
         specifier: ^16.12.0
         version: 16.12.0
+      lexical:
+        specifier: 0.41.0
+        version: 0.41.0
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@base-ui/react':
         specifier: ^1.2.0
         version: 1.3.0(@types/react@19.1.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@lexical/react':
-        specifier: 0.41.0
-        version: 0.41.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(yjs@13.6.28)
       '@next/third-parties':
         specifier: ^15.3.6
         version: 15.3.6(next@15.4.11(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))(react@19.2.3)
@@ -80,9 +77,6 @@ importers:
       graphql:
         specifier: ^16.12.0
         version: 16.12.0
-      lexical:
-        specifier: 0.41.0
-        version: 0.41.0
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.3)

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -28,6 +28,7 @@ import { SubscriptFeatureClient as SubscriptFeatureClient_e70f5e05f09f93e00b997e
 import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { BlockquoteFeatureClient as BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { FootnoteShortcutFeatureClient as FootnoteShortcutFeatureClient_c9eb0c0c4f4eddc3060756b47cf6d3aa } from '@/blocks/Footnote/shortcutFeature.client'
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { default as default_80e5fdb60df5ca84bc544282529ce3be } from '../../../blocks/Math/AdminComponent'
 import { URLField as URLField_50bd533e6cc7d027cb7127769a4f2bf9 } from '@/blocks/SocialEmbed/components/URLField'
@@ -77,6 +78,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@/blocks/Footnote/shortcutFeature.client#FootnoteShortcutFeatureClient": FootnoteShortcutFeatureClient_c9eb0c0c4f4eddc3060756b47cf6d3aa,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "/blocks/Math/AdminComponent#default": default_80e5fdb60df5ca84bc544282529ce3be,
   "@/blocks/SocialEmbed/components/URLField#URLField": URLField_50bd533e6cc7d027cb7127769a4f2bf9,

--- a/src/blocks/Footnote/FootnoteLabel.tsx
+++ b/src/blocks/Footnote/FootnoteLabel.tsx
@@ -5,10 +5,16 @@ interface FootnoteLabelProps {
   siblingData: Partial<FootnoteBlock>
 }
 
+const PREVIEW_LIMIT = 20
+
+const truncate = (text: string): string =>
+  text.length > PREVIEW_LIMIT ? `${text.slice(0, PREVIEW_LIMIT)}…` : text
+
 export const FootnoteLabel: React.FC<FootnoteLabelProps> = ({
   siblingData: { index, sourceId, note },
 }) => {
   if (!note) return <span>Footnote</span>
+  if (typeof index !== "number") return <span>{truncate(note)}</span>
   if (sourceId) return <span>{`↗ [${index}]`}</span>
   return <span>{`[${index}]`}</span>
 }

--- a/src/blocks/Footnote/FootnoteLabel.tsx
+++ b/src/blocks/Footnote/FootnoteLabel.tsx
@@ -5,16 +5,10 @@ interface FootnoteLabelProps {
   siblingData: Partial<FootnoteBlock>
 }
 
-const PREVIEW_LIMIT = 20
-
-const truncate = (text: string): string =>
-  text.length > PREVIEW_LIMIT ? `${text.slice(0, PREVIEW_LIMIT)}…` : text
-
 export const FootnoteLabel: React.FC<FootnoteLabelProps> = ({
   siblingData: { index, sourceId, note },
 }) => {
   if (!note) return <span>Footnote</span>
-  if (typeof index !== "number") return <span>{truncate(note)}</span>
   if (sourceId) return <span>{`↗ [${index}]`}</span>
   return <span>{`[${index}]`}</span>
 }

--- a/src/blocks/Footnote/FootnoteLabel.tsx
+++ b/src/blocks/Footnote/FootnoteLabel.tsx
@@ -2,13 +2,19 @@ import type { FootnoteBlock } from "@/payload-types"
 import React from "react"
 
 interface FootnoteLabelProps {
-  siblingData: Partial<FootnoteBlock>
+  siblingData?: Partial<FootnoteBlock> | null
 }
 
-export const FootnoteLabel: React.FC<FootnoteLabelProps> = ({
-  siblingData: { index, sourceId, note },
-}) => {
+const PREVIEW_LIMIT = 20
+
+const truncate = (text: string): string =>
+  text.length > PREVIEW_LIMIT ? `${text.slice(0, PREVIEW_LIMIT)}…` : text
+
+export const FootnoteLabel: React.FC<FootnoteLabelProps> = ({ siblingData }) => {
+  const note = siblingData?.note
+  const sourceId = siblingData?.sourceId
+
   if (!note) return <span>Footnote</span>
-  if (sourceId) return <span>{`↗ [${index}]`}</span>
-  return <span>{`[${index}]`}</span>
+  if (sourceId) return <span>{`↗ ${truncate(note)}`}</span>
+  return <span>{truncate(note)}</span>
 }

--- a/src/blocks/Footnote/FootnoteLabel.tsx
+++ b/src/blocks/Footnote/FootnoteLabel.tsx
@@ -2,13 +2,19 @@ import type { FootnoteBlock } from "@/payload-types"
 import React from "react"
 
 interface FootnoteLabelProps {
-  siblingData: Partial<FootnoteBlock>
+  siblingData?: Partial<FootnoteBlock> | null
 }
 
-export const FootnoteLabel: React.FC<FootnoteLabelProps> = ({
-  siblingData: { index, sourceId },
-}) => {
-  if (typeof index !== "number") return <span>Footnote</span>
-  if (sourceId) return <span>{`↗ [${index}]`}</span>
-  return <span>{`[${index}]`}</span>
+const PREVIEW_LIMIT = 20
+
+const truncate = (text: string): string =>
+  text.length > PREVIEW_LIMIT ? `${text.slice(0, PREVIEW_LIMIT)}…` : text
+
+export const FootnoteLabel: React.FC<FootnoteLabelProps> = ({ siblingData }) => {
+  const note = siblingData?.note
+  const sourceId = siblingData?.sourceId
+
+  if (!note) return <span>Footnote</span>
+  if (sourceId) return <span>{`↗ ${truncate(note)}`}</span>
+  return <span>{truncate(note)}</span>
 }

--- a/src/blocks/Footnote/FootnoteLabel.tsx
+++ b/src/blocks/Footnote/FootnoteLabel.tsx
@@ -2,19 +2,13 @@ import type { FootnoteBlock } from "@/payload-types"
 import React from "react"
 
 interface FootnoteLabelProps {
-  siblingData?: Partial<FootnoteBlock> | null
+  siblingData: Partial<FootnoteBlock>
 }
 
-const PREVIEW_LIMIT = 20
-
-const truncate = (text: string): string =>
-  text.length > PREVIEW_LIMIT ? `${text.slice(0, PREVIEW_LIMIT)}…` : text
-
-export const FootnoteLabel: React.FC<FootnoteLabelProps> = ({ siblingData }) => {
-  const note = siblingData?.note
-  const sourceId = siblingData?.sourceId
-
+export const FootnoteLabel: React.FC<FootnoteLabelProps> = ({
+  siblingData: { index, sourceId, note },
+}) => {
   if (!note) return <span>Footnote</span>
-  if (sourceId) return <span>{`↗ ${truncate(note)}`}</span>
-  return <span>{truncate(note)}</span>
+  if (sourceId) return <span>{`↗ [${index}]`}</span>
+  return <span>{`[${index}]`}</span>
 }

--- a/src/blocks/Footnote/InsertExistingFootnote.tsx
+++ b/src/blocks/Footnote/InsertExistingFootnote.tsx
@@ -11,7 +11,9 @@ export const InsertExistingFootnote: React.FC = () => {
   const { setValue: setSourceId } = useField<string>({ path: "sourceId" })
   const { setValue: setNote } = useField<string>({ path: "note" })
 
-  const footnotes = (data?.footnotes as NonNullable<FootnotesField>) ?? []
+  const footnotes = ((data?.footnotes as NonNullable<FootnotesField>) ?? []).filter(
+    (footnote) => footnote.note,
+  )
 
   const handleChange = (value: ReactSelectOption | ReactSelectOption[]) => {
     const option = Array.isArray(value) ? value[0] : value

--- a/src/blocks/Footnote/shortcutFeature.client.tsx
+++ b/src/blocks/Footnote/shortcutFeature.client.tsx
@@ -1,23 +1,17 @@
 "use client"
 
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext"
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  type TriggerFn,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin"
 import {
   $createInlineBlockNode,
   $isInlineBlockNode,
   createClientFeature,
 } from "@payloadcms/richtext-lexical/client"
-import {
-  $getRoot,
-  $isElementNode,
-  $isTextNode,
-  type LexicalNode,
-  TextNode,
-} from "@payloadcms/richtext-lexical/lexical"
-import { useLexicalComposerContext } from "@payloadcms/richtext-lexical/lexical/react/LexicalComposerContext"
-import {
-  LexicalTypeaheadMenuPlugin,
-  MenuOption,
-  type TriggerFn,
-} from "@payloadcms/richtext-lexical/lexical/react/LexicalTypeaheadMenuPlugin"
+import { $getRoot, $isElementNode, $isTextNode, type LexicalNode, TextNode } from "lexical"
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { createPortal } from "react-dom"
 

--- a/src/blocks/Footnote/shortcutFeature.client.tsx
+++ b/src/blocks/Footnote/shortcutFeature.client.tsx
@@ -1,17 +1,23 @@
 "use client"
 
-import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext"
-import {
-  LexicalTypeaheadMenuPlugin,
-  MenuOption,
-  type TriggerFn,
-} from "@lexical/react/LexicalTypeaheadMenuPlugin"
 import {
   $createInlineBlockNode,
   $isInlineBlockNode,
   createClientFeature,
 } from "@payloadcms/richtext-lexical/client"
-import { $getRoot, $isElementNode, $isTextNode, type LexicalNode, TextNode } from "lexical"
+import {
+  $getRoot,
+  $isElementNode,
+  $isTextNode,
+  type LexicalNode,
+  TextNode,
+} from "@payloadcms/richtext-lexical/lexical"
+import { useLexicalComposerContext } from "@payloadcms/richtext-lexical/lexical/react/LexicalComposerContext"
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  type TriggerFn,
+} from "@payloadcms/richtext-lexical/lexical/react/LexicalTypeaheadMenuPlugin"
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { createPortal } from "react-dom"
 

--- a/src/blocks/Footnote/shortcutFeature.client.tsx
+++ b/src/blocks/Footnote/shortcutFeature.client.tsx
@@ -15,16 +15,19 @@ import { $getRoot, $isElementNode, $isTextNode, type LexicalNode, TextNode } fro
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { createPortal } from "react-dom"
 
+import type { FootnoteBlock } from "@/payload-types"
+
+type CreateInlineBlockFields = Parameters<typeof $createInlineBlockNode>[0]
+const createFootnoteNode = (fields: Partial<FootnoteBlock> & { blockType: "footnote" }) =>
+  $createInlineBlockNode(fields as unknown as CreateInlineBlockFields)
+
 const SHORTCUT_REGEX = /\[\^([^\]]+)\]/
 const TRIGGER_REGEX = /(^|\s|\()(\[\^([^\]]*))$/
 const PREVIEW_LIMIT = 60
 const MAX_SUGGESTIONS = 8
 
-interface FootnoteSource {
+type FootnoteSource = Pick<FootnoteBlock, "note" | "attributionEnabled" | "link"> & {
   id: string
-  note: string
-  attributionEnabled?: boolean
-  link?: unknown
 }
 
 const collectFootnoteSources = (): FootnoteSource[] => {
@@ -34,14 +37,7 @@ const collectFootnoteSources = (): FootnoteSource[] => {
   while (stack.length) {
     const node = stack.pop()!
     if ($isInlineBlockNode(node)) {
-      const fields = node.getFields() as {
-        id?: string
-        blockType?: string
-        sourceId?: string | null
-        note?: string
-        attributionEnabled?: boolean
-        link?: unknown
-      }
+      const fields = node.getFields() as Partial<FootnoteBlock>
       if (
         fields.blockType === "footnote" &&
         !fields.sourceId &&
@@ -69,9 +65,9 @@ const triggerFn: TriggerFn = (text) => {
   const match = TRIGGER_REGEX.exec(text)
   if (!match) return null
   return {
-    leadOffset: match.index + match[1].length,
-    matchingString: match[3],
-    replaceableString: match[2],
+    leadOffset: match.index + (match[1]?.length ?? 0),
+    matchingString: match[3] ?? "",
+    replaceableString: match[2] ?? "",
   }
 }
 
@@ -121,7 +117,7 @@ const FootnoteShortcutPlugin: React.FC = () => {
       if (!matchNode) return
 
       const existing = collectFootnoteSources().find((s) => s.note === noteText) ?? null
-      const footnote = $createInlineBlockNode(
+      const footnote = createFootnoteNode(
         existing
           ? {
               blockName: "",
@@ -158,7 +154,7 @@ const FootnoteShortcutPlugin: React.FC = () => {
           const parts = node.splitText(splitOffset)
           triggerNode = parts[parts.length - 1]!
         }
-        const footnote = $createInlineBlockNode({
+        const footnote = createFootnoteNode({
           blockName: "",
           blockType: "footnote",
           sourceId: option.source.id,

--- a/src/blocks/Footnote/shortcutFeature.client.tsx
+++ b/src/blocks/Footnote/shortcutFeature.client.tsx
@@ -1,0 +1,237 @@
+"use client"
+
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext"
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  type TriggerFn,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin"
+import {
+  $createInlineBlockNode,
+  $isInlineBlockNode,
+  createClientFeature,
+} from "@payloadcms/richtext-lexical/client"
+import { $getRoot, $isElementNode, $isTextNode, type LexicalNode, TextNode } from "lexical"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
+import { createPortal } from "react-dom"
+
+const SHORTCUT_REGEX = /\[\^([^\]]+)\]/
+const TRIGGER_REGEX = /(^|\s|\()(\[\^([^\]]*))$/
+const PREVIEW_LIMIT = 60
+const MAX_SUGGESTIONS = 8
+
+interface FootnoteSource {
+  id: string
+  note: string
+  attributionEnabled?: boolean
+  link?: unknown
+}
+
+const collectFootnoteSources = (): FootnoteSource[] => {
+  const out: FootnoteSource[] = []
+  const seen = new Set<string>()
+  const stack: LexicalNode[] = [$getRoot()]
+  while (stack.length) {
+    const node = stack.pop()!
+    if ($isInlineBlockNode(node)) {
+      const fields = node.getFields() as {
+        id?: string
+        blockType?: string
+        sourceId?: string | null
+        note?: string
+        attributionEnabled?: boolean
+        link?: unknown
+      }
+      if (
+        fields.blockType === "footnote" &&
+        !fields.sourceId &&
+        fields.id &&
+        fields.note &&
+        !seen.has(fields.id)
+      ) {
+        seen.add(fields.id)
+        out.push({
+          id: fields.id,
+          note: fields.note,
+          attributionEnabled: fields.attributionEnabled,
+          link: fields.link,
+        })
+      }
+    }
+    if ($isElementNode(node)) {
+      for (const child of node.getChildren()) stack.push(child)
+    }
+  }
+  return out
+}
+
+const triggerFn: TriggerFn = (text) => {
+  const match = TRIGGER_REGEX.exec(text)
+  if (!match) return null
+  return {
+    leadOffset: match.index + match[1].length,
+    matchingString: match[3],
+    replaceableString: match[2],
+  }
+}
+
+class FootnoteMenuOption extends MenuOption {
+  source: FootnoteSource
+  constructor(source: FootnoteSource) {
+    super(source.id)
+    this.source = source
+  }
+}
+
+const truncate = (text: string): string =>
+  text.length > PREVIEW_LIMIT ? `${text.slice(0, PREVIEW_LIMIT)}…` : text
+
+const FootnoteShortcutPlugin: React.FC = () => {
+  const [editor] = useLexicalComposerContext()
+  const [queryString, setQueryString] = useState<string | null>(null)
+  const [sources, setSources] = useState<FootnoteSource[]>([])
+
+  useEffect(() => {
+    if (queryString === null) return
+    editor.getEditorState().read(() => {
+      setSources(collectFootnoteSources())
+    })
+  }, [editor, queryString])
+
+  const options = useMemo(() => {
+    const q = (queryString ?? "").toLowerCase().trim()
+    return sources
+      .filter((s) => (q ? s.note.toLowerCase().includes(q) : true))
+      .slice(0, MAX_SUGGESTIONS)
+      .map((s) => new FootnoteMenuOption(s))
+  }, [sources, queryString])
+
+  useEffect(() => {
+    return editor.registerNodeTransform(TextNode, (textNode) => {
+      if (!$isTextNode(textNode) || !textNode.isSimpleText()) return
+      const text = textNode.getTextContent()
+      const match = SHORTCUT_REGEX.exec(text)
+      if (!match) return
+      const noteText = match[1]?.trim()
+      if (!noteText) return
+      const matchStart = match.index
+      const matchEnd = matchStart + match[0].length
+      const splits = textNode.splitText(matchStart, matchEnd)
+      const matchNode = splits.find((n) => n.getTextContent() === match[0])
+      if (!matchNode) return
+
+      const existing = collectFootnoteSources().find((s) => s.note === noteText) ?? null
+      const footnote = $createInlineBlockNode(
+        existing
+          ? {
+              blockName: "",
+              blockType: "footnote",
+              sourceId: existing.id,
+              note: existing.note,
+              attributionEnabled: existing.attributionEnabled,
+              link: existing.link,
+            }
+          : { blockName: "", blockType: "footnote", note: noteText },
+      )
+      matchNode.replace(footnote)
+    })
+  }, [editor])
+
+  const onSelectOption = useCallback(
+    (
+      option: FootnoteMenuOption,
+      textNodeContainingQuery: TextNode | null,
+      closeMenu: () => void,
+      matchingString: string,
+    ) => {
+      editor.update(() => {
+        const node = textNodeContainingQuery
+        if (!node) {
+          closeMenu()
+          return
+        }
+        const triggerLength = 2 + matchingString.length // [^ + typed
+        const text = node.getTextContent()
+        const splitOffset = text.length - triggerLength
+        let triggerNode = node
+        if (splitOffset > 0) {
+          const parts = node.splitText(splitOffset)
+          triggerNode = parts[parts.length - 1]!
+        }
+        const footnote = $createInlineBlockNode({
+          blockName: "",
+          blockType: "footnote",
+          sourceId: option.source.id,
+          note: option.source.note,
+          attributionEnabled: option.source.attributionEnabled,
+          link: option.source.link,
+        })
+        triggerNode.replace(footnote)
+        closeMenu()
+      })
+    },
+    [editor],
+  )
+
+  return (
+    <LexicalTypeaheadMenuPlugin<FootnoteMenuOption>
+      onQueryChange={setQueryString}
+      onSelectOption={onSelectOption}
+      options={options}
+      triggerFn={triggerFn}
+      menuRenderFn={(
+        anchorElementRef,
+        { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex },
+      ) => {
+        if (!anchorElementRef.current || options.length === 0) return null
+        return createPortal(
+          <div
+            style={{
+              background: "var(--theme-elevation-50, #fff)",
+              border: "1px solid var(--theme-elevation-150, #ddd)",
+              borderRadius: 4,
+              boxShadow: "0 6px 24px rgba(0,0,0,0.15)",
+              maxWidth: 360,
+              minWidth: 240,
+              padding: 4,
+              zIndex: 10,
+            }}
+          >
+            {options.map((option, i) => (
+              <button
+                key={option.key}
+                onClick={() => selectOptionAndCleanUp(option)}
+                onMouseEnter={() => setHighlightedIndex(i)}
+                ref={(el) => option.setRefElement(el)}
+                style={{
+                  background:
+                    i === selectedIndex ? "var(--theme-elevation-100, #eef)" : "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  display: "block",
+                  fontSize: 13,
+                  padding: "6px 8px",
+                  textAlign: "left",
+                  width: "100%",
+                }}
+                type="button"
+              >
+                {truncate(option.source.note)}
+              </button>
+            ))}
+          </div>,
+          anchorElementRef.current,
+        )
+      }}
+    />
+  )
+}
+
+export const FootnoteShortcutFeatureClient = createClientFeature(() => ({
+  plugins: [
+    {
+      Component: FootnoteShortcutPlugin,
+      position: "normal",
+    },
+  ],
+}))

--- a/src/blocks/Footnote/shortcutFeature.ts
+++ b/src/blocks/Footnote/shortcutFeature.ts
@@ -1,0 +1,8 @@
+import { createServerFeature } from "@payloadcms/richtext-lexical"
+
+export const FootnoteShortcutFeature = createServerFeature({
+  feature: {
+    ClientFeature: "@/blocks/Footnote/shortcutFeature.client#FootnoteShortcutFeatureClient",
+  },
+  key: "footnoteShortcut",
+})

--- a/src/collections/Articles/hooks/generateFootnotes.ts
+++ b/src/collections/Articles/hooks/generateFootnotes.ts
@@ -80,6 +80,7 @@ export const collectFootnotes = (editorState?: SerializedEditorState): Footnotes
 }
 
 export const generateFootnotes: CollectionBeforeChangeHook<Article> = ({ data }) => {
+  // if (isAutosave(req)) return data
   if (data?.content) {
     data.footnotes = collectFootnotes(data.content as SerializedEditorState | undefined)
   }

--- a/src/collections/Articles/hooks/generateFootnotes.ts
+++ b/src/collections/Articles/hooks/generateFootnotes.ts
@@ -21,68 +21,88 @@ const getDedupeKey = (fields: FootnoteBlock): string => {
   return `${fields.note}|${refId}`
 }
 
-export const collectFootnotes = (editorState?: SerializedEditorState): FootnotesField => {
+const collectByNode = (node: SerializedLexicalNode, into: Map<string, FootnoteFields>): void => {
+  if (!node || typeof node !== "object") return
+
+  if (node.type === "inlineBlock") {
+    const inlineNode = node as SerializedInlineBlockNode<FootnoteBlock>
+    const fields = inlineNode.fields as FootnoteFields
+    if (fields.blockType === "footnote" && !fields.sourceId) {
+      if (!fields.id) {
+        fields.id = crypto.randomUUID()
+      }
+      into.set(fields.id, fields)
+    }
+  }
+
+  if ("children" in node && Array.isArray(node.children)) {
+    node.children.forEach((child: SerializedLexicalNode) => collectByNode(child, into))
+  }
+}
+
+export const collectFootnotes = (editorState?: SerializedEditorState | null): FootnotesField => {
   if (!editorState || typeof editorState !== "object") return []
 
   const rootChildren = editorState.root?.children
   if (!Array.isArray(rootChildren)) return []
 
-  // Phase 1: single traversal — collect all footnotes in document order, index originals by id
-  const collected: FootnoteFields[] = []
+  // Phase 1: index all original (non-reference) footnote blocks by id
   const blockById = new Map<string, FootnoteFields>()
+  rootChildren.forEach((child: SerializedLexicalNode) => collectByNode(child, blockById))
 
-  const visit = (node: SerializedLexicalNode): void => {
-    if (!node || typeof node !== "object") return
-    if (node.type === "inlineBlock") {
-      const fields = (node as SerializedInlineBlockNode<FootnoteBlock>).fields as FootnoteFields
-      if (fields.blockType === "footnote") {
-        if (!fields.id) fields.id = crypto.randomUUID()
-        collected.push(fields)
-        if (!fields.sourceId) blockById.set(fields.id, fields)
-      }
-    }
-    if ("children" in node && Array.isArray(node.children)) node.children.forEach(visit)
-  }
-  rootChildren.forEach(visit)
-
-  // Phase 2: linear pass over collected footnotes — resolve refs, dedup, assign indices
   type FootnoteResult = NonNullable<FootnotesField>[number]
+
+  // Phase 2: resolve references, then dedup and assign indices
   let footnoteIndex = 0
   const result: FootnotesField = []
   const seen = new Map<string, number>()
 
-  for (const fields of collected) {
-    if (fields.sourceId) {
-      const source = blockById.get(fields.sourceId)
-      if (source) {
-        fields.note = source.note
-        fields.attributionEnabled = source.attributionEnabled
-        fields.link = source.link
-      } else {
-        // Orphaned reference: promote to standalone original
-        fields.sourceId = null
+  const visitNode = (node: SerializedLexicalNode) => {
+    if (!node || typeof node !== "object") return
+
+    if (node.type === "inlineBlock") {
+      const inlineNode = node as SerializedInlineBlockNode<FootnoteBlock>
+      const fields = inlineNode.fields as FootnoteFields
+
+      if (fields.blockType === "footnote") {
+        if (fields.sourceId) {
+          const source = blockById.get(fields.sourceId)
+          if (source) {
+            fields.note = source.note
+            fields.attributionEnabled = source.attributionEnabled
+            fields.link = source.link
+          } else {
+            // Orphaned reference: promote to standalone original
+            fields.sourceId = null
+          }
+        }
+
+        const key = getDedupeKey(fields)
+
+        if (seen.has(key)) {
+          fields.index = seen.get(key)!
+        } else {
+          footnoteIndex += 1
+          fields.index = footnoteIndex
+          seen.set(key, footnoteIndex)
+          result.push(fields as FootnoteResult)
+        }
       }
     }
 
-    const key = getDedupeKey(fields)
-
-    if (seen.has(key)) {
-      fields.index = seen.get(key)!
-    } else {
-      footnoteIndex += 1
-      fields.index = footnoteIndex
-      seen.set(key, footnoteIndex)
-      result.push(fields as FootnoteResult)
+    if ("children" in node && Array.isArray(node.children)) {
+      node.children.forEach((child: SerializedLexicalNode) => visitNode(child))
     }
   }
+
+  rootChildren.forEach((child: SerializedLexicalNode) => visitNode(child))
 
   return result
 }
 
 export const generateFootnotes: CollectionBeforeChangeHook<Article> = ({ data }) => {
-  // if (isAutosave(req)) return data
   if (data?.content) {
-    data.footnotes = collectFootnotes(data.content as SerializedEditorState | undefined)
+    data.footnotes = collectFootnotes(data.content as SerializedEditorState)
   }
   return data
 }

--- a/src/collections/Articles/hooks/generateFootnotes.ts
+++ b/src/collections/Articles/hooks/generateFootnotes.ts
@@ -21,88 +21,68 @@ const getDedupeKey = (fields: FootnoteBlock): string => {
   return `${fields.note}|${refId}`
 }
 
-const collectByNode = (node: SerializedLexicalNode, into: Map<string, FootnoteFields>): void => {
-  if (!node || typeof node !== "object") return
-
-  if (node.type === "inlineBlock") {
-    const inlineNode = node as SerializedInlineBlockNode<FootnoteBlock>
-    const fields = inlineNode.fields as FootnoteFields
-    if (fields.blockType === "footnote" && !fields.sourceId) {
-      if (!fields.id) {
-        fields.id = crypto.randomUUID()
-      }
-      into.set(fields.id, fields)
-    }
-  }
-
-  if ("children" in node && Array.isArray(node.children)) {
-    node.children.forEach((child: SerializedLexicalNode) => collectByNode(child, into))
-  }
-}
-
-export const collectFootnotes = (editorState?: SerializedEditorState | null): FootnotesField => {
+export const collectFootnotes = (editorState?: SerializedEditorState): FootnotesField => {
   if (!editorState || typeof editorState !== "object") return []
 
   const rootChildren = editorState.root?.children
   if (!Array.isArray(rootChildren)) return []
 
-  // Phase 1: index all original (non-reference) footnote blocks by id
+  // Phase 1: single traversal — collect all footnotes in document order, index originals by id
+  const collected: FootnoteFields[] = []
   const blockById = new Map<string, FootnoteFields>()
-  rootChildren.forEach((child: SerializedLexicalNode) => collectByNode(child, blockById))
 
+  const visit = (node: SerializedLexicalNode): void => {
+    if (!node || typeof node !== "object") return
+    if (node.type === "inlineBlock") {
+      const fields = (node as SerializedInlineBlockNode<FootnoteBlock>).fields as FootnoteFields
+      if (fields.blockType === "footnote") {
+        if (!fields.id) fields.id = crypto.randomUUID()
+        collected.push(fields)
+        if (!fields.sourceId) blockById.set(fields.id, fields)
+      }
+    }
+    if ("children" in node && Array.isArray(node.children)) node.children.forEach(visit)
+  }
+  rootChildren.forEach(visit)
+
+  // Phase 2: linear pass over collected footnotes — resolve refs, dedup, assign indices
   type FootnoteResult = NonNullable<FootnotesField>[number]
-
-  // Phase 2: resolve references, then dedup and assign indices
   let footnoteIndex = 0
   const result: FootnotesField = []
   const seen = new Map<string, number>()
 
-  const visitNode = (node: SerializedLexicalNode) => {
-    if (!node || typeof node !== "object") return
-
-    if (node.type === "inlineBlock") {
-      const inlineNode = node as SerializedInlineBlockNode<FootnoteBlock>
-      const fields = inlineNode.fields as FootnoteFields
-
-      if (fields.blockType === "footnote") {
-        if (fields.sourceId) {
-          const source = blockById.get(fields.sourceId)
-          if (source) {
-            fields.note = source.note
-            fields.attributionEnabled = source.attributionEnabled
-            fields.link = source.link
-          } else {
-            // Orphaned reference: promote to standalone original
-            fields.sourceId = null
-          }
-        }
-
-        const key = getDedupeKey(fields)
-
-        if (seen.has(key)) {
-          fields.index = seen.get(key)!
-        } else {
-          footnoteIndex += 1
-          fields.index = footnoteIndex
-          seen.set(key, footnoteIndex)
-          result.push(fields as FootnoteResult)
-        }
+  for (const fields of collected) {
+    if (fields.sourceId) {
+      const source = blockById.get(fields.sourceId)
+      if (source) {
+        fields.note = source.note
+        fields.attributionEnabled = source.attributionEnabled
+        fields.link = source.link
+      } else {
+        // Orphaned reference: promote to standalone original
+        fields.sourceId = null
       }
     }
 
-    if ("children" in node && Array.isArray(node.children)) {
-      node.children.forEach((child: SerializedLexicalNode) => visitNode(child))
+    const key = getDedupeKey(fields)
+
+    if (seen.has(key)) {
+      fields.index = seen.get(key)!
+    } else {
+      footnoteIndex += 1
+      fields.index = footnoteIndex
+      seen.set(key, footnoteIndex)
+      result.push(fields as FootnoteResult)
     }
   }
-
-  rootChildren.forEach((child: SerializedLexicalNode) => visitNode(child))
 
   return result
 }
 
 export const generateFootnotes: CollectionBeforeChangeHook<Article> = ({ data }) => {
+  // if (isAutosave(req)) return data
   if (data?.content) {
-    data.footnotes = collectFootnotes(data.content as SerializedEditorState)
+    data.footnotes = collectFootnotes(data.content as SerializedEditorState | undefined)
   }
   return data
 }

--- a/src/collections/Articles/hooks/generateFootnotes.ts
+++ b/src/collections/Articles/hooks/generateFootnotes.ts
@@ -80,7 +80,6 @@ export const collectFootnotes = (editorState?: SerializedEditorState): Footnotes
 }
 
 export const generateFootnotes: CollectionBeforeChangeHook<Article> = ({ data }) => {
-  // if (isAutosave(req)) return data
   if (data?.content) {
     data.footnotes = collectFootnotes(data.content as SerializedEditorState | undefined)
   }

--- a/src/collections/Articles/hooks/generateFootnotes.ts
+++ b/src/collections/Articles/hooks/generateFootnotes.ts
@@ -100,14 +100,8 @@ export const collectFootnotes = (editorState?: SerializedEditorState | null): Fo
   return result
 }
 
-export const generateFootnotes: CollectionBeforeChangeHook<Article> = ({ data, req }) => {
-  const autosaveQuery = req?.query?.autosave
-  const isAutosave =
-    autosaveQuery === true ||
-    autosaveQuery === "true" ||
-    autosaveQuery === 1 ||
-    autosaveQuery === "1"
-  if (!isAutosave && data?.content) {
+export const generateFootnotes: CollectionBeforeChangeHook<Article> = ({ data }) => {
+  if (data?.content) {
     data.footnotes = collectFootnotes(data.content as SerializedEditorState)
   }
   return data

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -5,6 +5,7 @@ import { writer } from "@/access/writer"
 import { Banner } from "@/blocks/Banner/config"
 import { Code } from "@/blocks/Code/config"
 import { FootnoteBlock } from "@/blocks/Footnote/config"
+import { FootnoteShortcutFeature } from "@/blocks/Footnote/shortcutFeature"
 import { DisplayMathBlock, InlineMathBlock } from "@/blocks/Math/config"
 import { MediaBlock } from "@/blocks/MediaBlock/config"
 import { MediaCollageBlock } from "@/blocks/MediaCollageBlock/config"
@@ -130,6 +131,7 @@ export const Articles: CollectionConfig = {
                       ],
                       inlineBlocks: [InlineMathBlock, FootnoteBlock],
                     }),
+                    FootnoteShortcutFeature(),
                     FixedToolbarFeature(),
                     InlineToolbarFeature(),
                     HorizontalRuleFeature(),

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -342,10 +342,7 @@ export const Articles: CollectionConfig = {
   },
   versions: {
     drafts: {
-      autosave: {
-        interval: 800,
-        showSaveDraftButton: true,
-      },
+      autosave: true,
       schedulePublish: true,
     },
     maxPerDoc: 50,

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -342,7 +342,10 @@ export const Articles: CollectionConfig = {
   },
   versions: {
     drafts: {
-      autosave: true,
+      autosave: {
+        interval: 800,
+        showSaveDraftButton: true,
+      },
       schedulePublish: true,
     },
     maxPerDoc: 50,


### PR DESCRIPTION

## Context

The footnote UI is a little clunky
* Footnote numbers were only generated on a full save which only Editor-roled users were able to do
* Even still, the payload update was sent down to the client before the number was generated, so instead we opt for the first 20 characters of the citation. 
* Adds a `[^<text>]` pattern to auto convert to a footnote


## Test Plan

<!-- How can someone test to ensure that your PR does what you say it does? -->
