### PR TITLE
Adjust Anchor Links for Sticky Header

### DIFF
--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -141,7 +141,7 @@
     @apply bg-background text-foreground;
   }
   html {
-    @apply scroll-smooth font-sans;
+    @apply scroll-pt-20 scroll-smooth font-sans;
   }
   h1,
   h2,


### PR DESCRIPTION
## Context

Clicking on a footnote link would smooth scroll you down but the footnote would be covered by the header. 

This adds an offset to clear the header.

## Test Plan

<!-- How can someone test to ensure that your PR does what you say it does? -->
