### PR TITLE
(test)Fix: Forced Image Downloads via Domain Isolation

### DIFF
--- a/src/components/Media/ImageMedia/index.tsx
+++ b/src/components/Media/ImageMedia/index.tsx
@@ -62,6 +62,7 @@ export const ImageMedia: React.FC<ImageMediaProps> = ({
   loading,
   fill,
   style,
+  unoptimized = true,
   ...props
 }) => {
   if (!media.url) return null
@@ -102,6 +103,7 @@ export const ImageMedia: React.FC<ImageMediaProps> = ({
       sizes={sizes}
       quality={quality}
       priority={priority}
+      unoptimized={unoptimized}
       fetchPriority={priority ? "high" : undefined}
       loading={loading}
       placeholder="blur"


### PR DESCRIPTION
## Context
I don't enjoy the forced attachment downloads on production. However they are used by default for security purposes. 

## Test Plan
How to Verify
1.  Inspect an Image: Open the inspector and verify the <img> tag src points directly to Supabase/S3 (or /media/ in local dev) rather than /_next/image.
2.  Check Headers: In the Network tab, verify the image request no longer contains the X-Nextjs-Cache header, confirming it is bypassing the proxy.
3.  View Inline: Right-click a WebP image and "Open in new tab." It should display in the browser.

## Question:
_Jarvis_ is telling me that its currently using a redundant cache, where /_next/image cache stored re-optimized versions of images, which may be unnecessary because payload already pre-processing images into sized variants and webp format. and a possible  deduced Server Load. Because our Next.js server no longer needs to spend CPU cycles re-processing images that have already been optimized by the CMS. 

Any ideas of the validity of these statements?