### PR TITLE
Fix Code Blocks Theming when set to `system`

### DIFF
--- a/src/blocks/Code/Component.client.tsx
+++ b/src/blocks/Code/Component.client.tsx
@@ -11,7 +11,7 @@ type Props = {
 }
 
 export const Code: React.FC<Props> = ({ code, language = "" }) => {
-  const { theme } = useTheme()
+  const { resolvedTheme } = useTheme()
 
   if (!code) return null
 
@@ -19,7 +19,7 @@ export const Code: React.FC<Props> = ({ code, language = "" }) => {
     <Highlight
       code={code}
       language={language}
-      theme={theme === "dark" ? themes.vsDark : themes.vsLight}
+      theme={resolvedTheme === "dark" ? themes.vsDark : themes.vsLight}
     >
       {({ getLineProps, getTokenProps, tokens }) => (
         <pre className="bg-background overflow-x-auto rounded-sm border p-3 text-sm">


### PR DESCRIPTION
## Context

Closes #651 

Fixes CodeBlock system coloring.

 When next-themes is set to "system", useTheme() returns theme === "system" — not "dark" or "light". The check theme 
  === "dark" fails, so it always falls back to vsLight regardless of what the OS color scheme actually is.

  The fix is to use resolvedTheme instead, which next-themes resolves to the actual "dark" or "light" value after
  evaluating the system preference:

## Test Plan

Click the theme button and set it to `light` then `system`, while having your system set to dark mode. See that the code block text is now visible.
