### PR TITLE
Update AdminBar with Collection Id

### DIFF
--- a/src/app/(frontend)/articles/[slug]/page.tsx
+++ b/src/app/(frontend)/articles/[slug]/page.tsx
@@ -9,12 +9,13 @@ import { Separator } from "@/components/ui/separator"
 import { ArticleHero } from "@/heros/ArticleHero"
 import { MathJaxProvider } from "@/providers/MathJaxProvider"
 import { generateMeta } from "@/utilities/generateMeta"
+import { queryArticleBySlug } from "@/utilities/queries"
 import { buildArticleJsonLd, buildBreadcrumbJsonLd } from "@/utilities/structuredData"
 import configPromise from "@payload-config"
 import type { Metadata } from "next"
 import { draftMode } from "next/headers"
 import { getPayload } from "payload"
-import React, { cache } from "react"
+import React from "react"
 
 export async function generateStaticParams(): Promise<{ slug: string | null | undefined }[]> {
   const payload = await getPayload({ config: configPromise })
@@ -44,27 +45,6 @@ interface Args {
     slug?: string
   }>
 }
-
-const queryArticleBySlug = cache(async (slug: string) => {
-  const { isEnabled: draft } = await draftMode()
-
-  const payload = await getPayload({ config: configPromise })
-
-  const result = await payload.find({
-    collection: "articles",
-    draft,
-    limit: 1,
-    overrideAccess: draft,
-    pagination: false,
-    where: {
-      slug: {
-        equals: slug,
-      },
-    },
-  })
-
-  return result.docs?.[0] || null
-})
 
 export async function generateMetadata({ params: paramsPromise }: Args): Promise<Metadata> {
   const { slug = "" } = await paramsPromise

--- a/src/components/AdminBar/client.tsx
+++ b/src/components/AdminBar/client.tsx
@@ -4,24 +4,10 @@ import { PaperIcon } from "@/components/Logo/icons/PaperIcon"
 import { getClientSideURL } from "@/utilities/getURL"
 import type { PayloadAdminBarProps } from "@payloadcms/admin-bar"
 import { PayloadAdminBar } from "@payloadcms/admin-bar"
-import { useRouter, useSelectedLayoutSegments } from "next/navigation"
-
-const labels = new Map<string, { plural: string; singular: string }>([
-  ["pages", { plural: "Pages", singular: "Page" }],
-  ["volumes", { plural: "Volumes", singular: "Volume" }],
-  ["articles", { plural: "Articles", singular: "Article" }],
-  ["authors", { plural: "Authors", singular: "Author" }],
-  ["topics", { plural: "Topics", singular: "Topic" }],
-])
-
-const labelKeys = Array.from(labels.keys())
+import { useRouter } from "next/navigation"
 
 export const AdminBarClient: React.FC<PayloadAdminBarProps> = (props) => {
-  const [segment] = useSelectedLayoutSegments()
   const router = useRouter()
-
-  const collection = (labelKeys.includes(segment || "") ? segment : "pages") as string
-  const collectionLabels = labels.get(collection)
 
   function onPreviewExit() {
     fetch("/next/exit-preview").then(() => {
@@ -38,17 +24,14 @@ export const AdminBarClient: React.FC<PayloadAdminBarProps> = (props) => {
       classNames={{
         logo: "hover:text-brand",
         user: "hidden md:inline underline-offset-2 hover:underline",
-        controls: "flex ml-auto gap-1.5 underline-offset-2 hover:underline",
+        controls: "flex ml-auto gap-1.5",
         create: "hidden md:inline underline-offset-2 hover:underline",
         edit: "hidden md:inline underline-offset-2 hover:underline",
         preview: "underline-offset-2 hover:underline",
         logout: "underline-offset-2 hover:underline",
       }}
       cmsURL={getClientSideURL()}
-      collectionSlug={collection}
-      collectionLabels={collectionLabels}
       logo={<PaperIcon className="size-4" />}
-      // onAuthChange={onAuthChange}
       onPreviewExit={onPreviewExit}
     />
   )

--- a/src/components/AdminBar/index.tsx
+++ b/src/components/AdminBar/index.tsx
@@ -37,8 +37,8 @@ function parsePath(pathname: string): { routeKey: string; docSlug: string | unde
   return { routeKey: "pages", docSlug: first || "home" }
 }
 
-async function queryDocId(routeKey: string, docSlug: string): Promise<string | undefined> {
-  const queries: Record<string, (slug: string) => Promise<{ id: number | string } | null>> = {
+async function queryDocId(routeKey: string, docSlug: string): Promise<number | undefined> {
+  const queries: Record<string, (slug: string) => Promise<{ id: number } | null>> = {
     articles: queryArticleBySlug,
     volumes: queryVolumeBySlug,
     authors: queryUserBySlug,
@@ -46,7 +46,7 @@ async function queryDocId(routeKey: string, docSlug: string): Promise<string | u
     pages: queryPageBySlug,
   }
   const doc = await queries[routeKey]?.(docSlug)
-  return doc?.id != null ? String(doc.id) : undefined
+  return doc?.id ?? undefined
 }
 
 export async function AdminBar(): Promise<React.ReactNode> {
@@ -64,7 +64,7 @@ export async function AdminBar(): Promise<React.ReactNode> {
     ? { plural: routeConfig.plural, singular: routeConfig.singular }
     : undefined
 
-  const id = docSlug ? await queryDocId(routeKey, docSlug) : undefined
+  const docId = docSlug ? await queryDocId(routeKey, docSlug) : undefined
 
   return (
     <div className="h-8 w-full bg-black text-white">
@@ -72,7 +72,7 @@ export async function AdminBar(): Promise<React.ReactNode> {
         preview={isEnabled}
         collectionSlug={collectionSlug}
         collectionLabels={collectionLabels}
-        id={id}
+        id={docId ? String(docId) : undefined}
       />
     </div>
   )

--- a/src/components/AdminBar/index.tsx
+++ b/src/components/AdminBar/index.tsx
@@ -1,16 +1,79 @@
-import { draftMode } from "next/headers"
+import { draftMode, headers } from "next/headers"
 import React from "react"
 
 import { getAuth } from "@/utilities/getAuth"
+import {
+  queryArticleBySlug,
+  queryPageBySlug,
+  queryTopicBySlug,
+  queryUserBySlug,
+  queryVolumeBySlug,
+} from "@/utilities/queries"
 import { AdminBarClient } from "./client"
+
+interface RouteConfig {
+  plural: string
+  singular: string
+  // Payload collection slug — differs from the route key when the frontend
+  // URL uses a different name (e.g. /authors → "users" collection).
+  collectionSlug: string
+}
+
+const routes = new Map<string, RouteConfig>([
+  ["pages", { collectionSlug: "pages", plural: "Pages", singular: "Page" }],
+  ["volumes", { collectionSlug: "volumes", plural: "Volumes", singular: "Volume" }],
+  ["articles", { collectionSlug: "articles", plural: "Articles", singular: "Article" }],
+  ["authors", { collectionSlug: "users", plural: "Authors", singular: "Author" }],
+  ["topics", { collectionSlug: "topics", plural: "Topics", singular: "Topic" }],
+])
+
+const collectionRouteKeys = new Set(["articles", "volumes", "authors", "topics"])
+
+function parsePath(pathname: string): { routeKey: string; docSlug: string | undefined } {
+  const [, first = "", second] = pathname.split("/")
+  if (collectionRouteKeys.has(first)) {
+    return { routeKey: first, docSlug: second || undefined }
+  }
+  return { routeKey: "pages", docSlug: first || "home" }
+}
+
+async function queryDocId(routeKey: string, docSlug: string): Promise<string | undefined> {
+  const queries: Record<string, (slug: string) => Promise<{ id: number | string } | null>> = {
+    articles: queryArticleBySlug,
+    volumes: queryVolumeBySlug,
+    authors: queryUserBySlug,
+    topics: queryTopicBySlug,
+    pages: queryPageBySlug,
+  }
+  const doc = await queries[routeKey]?.(docSlug)
+  return doc?.id != null ? String(doc.id) : undefined
+}
 
 export async function AdminBar(): Promise<React.ReactNode> {
   const { isEnabled } = await draftMode()
   const { user } = await getAuth()
   if (!user) return null
+
+  const headersList = await headers()
+  const pathname = headersList.get("x-pathname") ?? "/"
+  const { routeKey, docSlug } = parsePath(pathname)
+
+  const routeConfig = routes.get(routeKey)
+  const collectionSlug = routeConfig?.collectionSlug ?? routeKey
+  const collectionLabels = routeConfig
+    ? { plural: routeConfig.plural, singular: routeConfig.singular }
+    : undefined
+
+  const id = docSlug ? await queryDocId(routeKey, docSlug) : undefined
+
   return (
     <div className="h-8 w-full bg-black text-white">
-      <AdminBarClient preview={isEnabled} />
+      <AdminBarClient
+        preview={isEnabled}
+        collectionSlug={collectionSlug}
+        collectionLabels={collectionLabels}
+        id={id}
+      />
     </div>
   )
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,4 @@
-import type { NextRequest } from "next/server"
-import { NextResponse } from "next/server"
+import { type NextRequest, NextResponse } from "next/server"
 
 export function middleware(request: NextRequest): ReturnType<typeof NextResponse.next> {
   const requestHeaders = new Headers(request.headers)

--- a/src/utilities/queries.ts
+++ b/src/utilities/queries.ts
@@ -71,6 +71,20 @@ export const queryVolumeBySlug = cache(async (slug: string) => {
   return docs[0] || null
 })
 
+export const queryArticleBySlug = cache(async (slug: string) => {
+  const { isEnabled: draft } = await draftMode()
+  const payload = await getPayloadConfig()
+  const { docs } = await payload.find({
+    collection: "articles",
+    draft,
+    limit: 1,
+    overrideAccess: draft,
+    pagination: false,
+    where: { slug: { equals: slug } },
+  })
+  return docs[0] || null
+})
+
 export const queryPageBySlug = cache(async (slug: string) => {
   const { isEnabled: draft } = await draftMode()
   const payload = await getPayloadConfig()


### PR DESCRIPTION
## Context

Use cached queries to get the current page's collection id.

Use this inside of AdminBar to surface the `Edit Page` & `Edit Article` links.

Also update the collection labels.

## Test Plan

- [ ] Login in and visit any page and notice the links in admin bar are now relevant.
