### PR TITLE
Fix reversion during Next 16 merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "lucide-react": "^1.9.0",
     "next": "16.2.4",
     "next-sitemap": "^4.2.3",
-    "next-themes": "^0.4.6",
     "node-cache": "^5.1.2",
     "payload": "^3.84.1",
     "prism-react-renderer": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       next-sitemap:
         specifier: ^4.2.3
         version: 4.2.3(next@16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4))
-      next-themes:
-        specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       node-cache:
         specifier: ^5.1.2
         version: 5.1.2
@@ -4590,12 +4587,6 @@ packages:
     hasBin: true
     peerDependencies:
       next: '*'
-
-  next-themes@0.4.6:
-    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.2.4:
     resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
@@ -11083,11 +11074,6 @@ snapshots:
       fast-glob: 3.3.3
       minimist: 1.2.8
       next: 16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4)
-
-  next-themes@0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
 
   next@16.2.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4):
     dependencies:

--- a/src/blocks/Code/Component.client.tsx
+++ b/src/blocks/Code/Component.client.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useTheme } from "next-themes"
+import { useTheme } from "@wrksz/themes/client"
 import { Highlight, themes } from "prism-react-renderer"
 import React from "react"
 import { CopyButton } from "./CopyButton"


### PR DESCRIPTION
## Context

Code blocks reverted to `next-themes` package.

## Test Plan

- [ ] Theming is restored on staging.
