### PR TITLE
Fix GA4 private key OpenSSL decoder error

### DIFF
--- a/src/jobs/updateRecommendations/logic.ts
+++ b/src/jobs/updateRecommendations/logic.ts
@@ -61,7 +61,11 @@ export function readGA4Env(): {
 } {
   const propertyId = process.env.GA4_PROPERTY_ID
   const clientEmail = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL
+  // Some deployment platforms double-escape backslashes in env vars, producing
+  // \\n (three chars) instead of \n (two chars). Replace both levels.
   const privateKey = process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY?.replace(/\\n/g, "\n")
+    ?.replace(/\\n/g, "\n")
+    ?.trim()
   if (!propertyId || !clientEmail || !privateKey) {
     throw new Error(
       "Missing required env vars: GA4_PROPERTY_ID, GOOGLE_SERVICE_ACCOUNT_EMAIL, GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY",


### PR DESCRIPTION
Closes #696

## Summary

- The `updateRecommendations` job was failing every run in production with `error:1E08010C:DECODER routines::unsupported`. OpenSSL rejected the private key because some deployment platforms double-escape backslashes in env vars, so `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` arrived as `\\n` (three chars) rather than `\n` (two chars). One replacement pass left literal `\n` sequences in the key, producing a malformed PEM block.
- Fixed by applying `.replace(/\\n/g, "\n")` twice and adding `.trim()` in `readGA4Env()` (`src/jobs/updateRecommendations/logic.ts`).

## Test plan

- [ ] Trigger the `updateRecommendations` job in production and confirm it completes without the OpenSSL decoder error

🤖 Generated with [Claude Code](https://claude.com/claude-code)