### PR TITLE
Bugfix RSS Feed Links

### DIFF
--- a/src/utilities/generateRssFeed.ts
+++ b/src/utilities/generateRssFeed.ts
@@ -20,10 +20,13 @@ import { getServerSideURL } from "./getURL"
 const SITE_URL = getServerSideURL()
 
 const getMediaUrl = (url: string) => {
-  if (url.startsWith("http://") || url.startsWith("https://")) {
-    return url
+  const absolute =
+    url.startsWith("http://") || url.startsWith("https://") ? url : `${SITE_URL}${url}`
+  try {
+    return new URL(absolute).href
+  } catch {
+    return absolute
   }
-  return `${SITE_URL}${url}`
 }
 
 const resolveMedia = (media: number | Media): Media | null =>


### PR DESCRIPTION
## Context

We're using the unencoded urls for the image links which for RSS readers simply fails. Thanks to Ky for flagging it.

## Test Plan

<!-- How can someone test to ensure that your PR does what you say it does? -->
