### PR TITLE
fix: persist DATABASE_URI for preview deployments

### DIFF
--- a/dockerfiles/PragmaticPapers.Dockerfile
+++ b/dockerfiles/PragmaticPapers.Dockerfile
@@ -109,7 +109,7 @@ RUN apk add --no-cache postgresql-client
 # 1. Isolated Preview Logic (clones DB for PRs)
 # 2. Migration Logic (runs on the final target DB)
 RUN /usr/local/bin/modify-database-uri.sh && \
-    if [ -f /tmp/database_uri.env ]; then . /tmp/database_uri.env; fi && \
+    if [ -f /tmp/build.env ]; then . /tmp/build.env; fi && \
     /usr/local/bin/copy-database.sh && \
     echo "--- PHASE: DATABASE MIGRATIONS ---" && \
     pnpm payload migrate && \
@@ -118,7 +118,7 @@ RUN /usr/local/bin/modify-database-uri.sh && \
 # --- NEXT.JS BUILD ---
 RUN --mount=type=cache,id=nextjs,target=/app/.next/cache \
     echo "--- PHASE: BUILDING NEXT.JS ---" && \
-    if [ -f /tmp/database_uri.env ]; then . /tmp/database_uri.env; fi && \
+    if [ -f /tmp/build.env ]; then . /tmp/build.env; fi && \
     pnpm build && \
     echo "--- COMPLETED: BUILDING NEXT.JS ---"
 
@@ -143,6 +143,7 @@ RUN apk add --no-cache dumb-init libc6-compat \
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /tmp/build.env ./build.env
 
 # Prepare media directory and set permissions
 RUN mkdir -p public/media \

--- a/dockerfiles/scripts/copy-database.sh
+++ b/dockerfiles/scripts/copy-database.sh
@@ -103,6 +103,13 @@ TARGET_DB=$(echo "$TARGET_PARSED" | cut -d'|' -f5)
 echo "Source: $SOURCE_USER@$SOURCE_HOST:$SOURCE_PORT/$SOURCE_DB"
 echo "Target: $TARGET_USER@$TARGET_HOST:$TARGET_PORT/$TARGET_DB"
 
+# Guard against source and target being the same database
+if [ "$SOURCE_HOST" = "$TARGET_HOST" ] && [ "$SOURCE_PORT" = "$TARGET_PORT" ] && [ "$SOURCE_DB" = "$TARGET_DB" ]; then
+    echo "Source and target are the same database ($SOURCE_DB@$SOURCE_HOST:$SOURCE_PORT)"
+    echo "Skipping database copy to avoid dropping production data"
+    exit 0
+fi
+
 # Export PGPASSWORD for psql/createdb commands
 export PGPASSWORD="$TARGET_PASSWORD"
 

--- a/dockerfiles/scripts/modify-database-uri.sh
+++ b/dockerfiles/scripts/modify-database-uri.sh
@@ -13,6 +13,8 @@ if [ "$BUILD_ENV" != "preview" ]; then
     echo "BUILD_ENV is not 'preview' (current: ${BUILD_ENV:-not set})"
     echo "Skipping DATABASE_URI modification"
     echo "DATABASE_URI: $DATABASE_URI"
+    # Write default to build.env so COPY in Dockerfile doesn't fail
+    echo "export DATABASE_URI='$DATABASE_URI'" > /tmp/build.env
     exit 0
 fi
 
@@ -22,6 +24,7 @@ echo "BUILD_ENV: preview - proceeding with DATABASE_URI modification"
 if [ -z "$COOLIFY_FQDN" ]; then
     echo "COOLIFY_FQDN is not set, using DATABASE_URI as-is"
     echo "DATABASE_URI: $DATABASE_URI"
+    echo "export DATABASE_URI='$DATABASE_URI'" > /tmp/build.env
     exit 0
 fi
 
@@ -74,8 +77,8 @@ echo "New database name: $NEW_DB_NAME"
 echo "Modified DATABASE_URI: $NEW_DATABASE_URI"
 
 # Export the modified DATABASE_URI for subsequent commands
-# We'll write it to a file that can be sourced
-echo "export DATABASE_URI='$NEW_DATABASE_URI'" > /tmp/database_uri.env
+# Write to /tmp/build.env (persisted to runtime via COPY in Dockerfile)
+echo "export DATABASE_URI='$NEW_DATABASE_URI'" > /tmp/build.env
 
 echo "========================================"
 echo "Database URI modification complete"

--- a/dockerfiles/scripts/start.sh
+++ b/dockerfiles/scripts/start.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Source database URI override if present (for preview deployments)
-if [ -f build.env ]; then
-    . build.env
+if [ -f /app/build.env ]; then
+    . /app/build.env
 fi
 
 echo "========================================="

--- a/dockerfiles/scripts/start.sh
+++ b/dockerfiles/scripts/start.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# Source database URI override if present (for preview deployments)
+if [ -f build.env ]; then
+    . build.env
+fi
+
 echo "========================================="
 echo "Starting Pragmatic Papers Application"
 echo "Node version: $(node --version)"


### PR DESCRIPTION
## Problem

Preview deployments were connecting to the production database at runtime instead of the PR-specific database.

The build caching optimization (1575b1ee) removed the mechanism that persisted the modified DATABASE_URI to the runtime container. During build, modify-database-uri.sh creates a PR-specific database (e.g., pragmatic_papers_pr_705), but the runtime container still used the original DATABASE_URI pointing to pragmatic_papers.

## Changes

- modify-database-uri.sh: writes to /tmp/build.env for all exit paths (preview and non-preview)
- Dockerfile: copies /tmp/build.env from builder to runtime stage
- start.sh: sources build.env at startup to override DATABASE_URI
- copy-database.sh: adds same-database guard to prevent accidentally dropping production data when source and target are the same

## Testing

- Preview deployments should connect to pragmatic_papers_pr_<number> database
- Non-preview deployments (dev, staging, prod) should continue using the original DATABASE_URI
- Build caching is preserved