### PR TITLE
ci: run script tests in unit-tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit -- --run
 
+      - name: Run script tests
+        run: pnpm test:scripts -- --run
+
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `pnpm test:scripts` as a second step in the existing `unit-tests` CI job.

Script tests share the same profile as unit tests — fast, no database, no containers — so a separate job would only add runner startup overhead for a ~600ms suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBFZDd9T2sro8FDpQycjkq)_