### PR TITLE
Add post hook for migration formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ci": "payload migrate && pnpm build",
     "migrate": "payload migrate",
     "migrate:create": "payload migrate:create",
+    "postmigrate:create": "prettier --write src/migrations",
     "migrate:redo": "node scripts/redo-last-migration.mjs",
     "migrate:status": "payload migrate:status",
     "prepare": "husky",


### PR DESCRIPTION
## Context

Migrations (at least on my machine) autogenerate with single quotes. While it can just get cleaned up in commit hooks it feels kinda bad and the generated immediate diff is noisy in the migration index.

Any command with 'post' in front of it is called following the success of the command without post.

## Test Plan

Tested locally on my machine. 
