### PR TITLE
Prevent staging from getting search indexed

### DIFF
--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -6,6 +6,10 @@ declare global {
       NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: string
       NEXT_PUBLIC_SERVER_URL: string
       VERCEL_PROJECT_PRODUCTION_URL: string
+      // Deployment environment, set per Coolify resource. Only "production"
+      // is search-indexable; all other values (preview/staging/unset) are
+      // served with an X-Robots-Tag: noindex header from src/proxy.ts.
+      BUILD_ENV?: string
     }
   }
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -6,9 +6,6 @@ declare global {
       NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: string
       NEXT_PUBLIC_SERVER_URL: string
       VERCEL_PROJECT_PRODUCTION_URL: string
-      // Deployment environment, set per Coolify resource. Only "production"
-      // is search-indexable; all other values (preview/staging/unset) are
-      // served with an X-Robots-Tag: noindex header from src/proxy.ts.
       BUILD_ENV?: string
     }
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,19 @@ import { type NextRequest, NextResponse } from "next/server"
 export function proxy(request: NextRequest): ReturnType<typeof NextResponse.next> {
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set("x-pathname", request.nextUrl.pathname)
-  return NextResponse.next({ request: { headers: requestHeaders } })
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+
+  // Only the production deployment is indexable. Every other deployment (PR
+  // previews, staging) stays fully crawlable — so the sitemap and pages can be
+  // verified — but is kept out of search indexes via noindex. Crawling is
+  // intentionally left allowed (no robots.txt Disallow) so Google can actually
+  // fetch the page and honor the (new) noindex header.
+  if (process.env.BUILD_ENV !== "production") {
+    response.headers.set("X-Robots-Tag", "noindex, nofollow")
+  }
+
+  return response
 }
 
 export const config = {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,11 +6,11 @@ export function proxy(request: NextRequest): ReturnType<typeof NextResponse.next
 
   const response = NextResponse.next({ request: { headers: requestHeaders } })
 
-  // Only the production deployment is indexable. Every other deployment (PR
-  // previews, staging) stays fully crawlable — so the sitemap and pages can be
+  // Prevent staging (and PR previews) from being search index. Pages
+  // stays fully crawlable — so the sitemap and pages can be
   // verified — but is kept out of search indexes via noindex. Crawling is
   // intentionally left allowed (no robots.txt Disallow) so Google can actually
-  // fetch the page and honor the (new) noindex header.
+  // fetch the page, process, and then and honor the (new) noindex header.
   if (process.env.BUILD_ENV !== "production") {
     response.headers.set("X-Robots-Tag", "noindex, nofollow")
   }


### PR DESCRIPTION
## Context

Noticed that a couple of staging pages were getting crawled/indexed. They were never ranked highly but it's worth not polluting our SEO search space.

Adds a `no-index, nofollow` robots header. Counterintuitively, blocking crawling might cause google to keep the page indexed. 

## Test Plan

<!-- How can someone test to ensure that your PR does what you say it does? -->
