### PR TITLE
Make status relative and uncovered lines clickable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,8 @@ jobs:
           gh-font-read-token: ${{ secrets.GH_FONT_READ }}
           payload-secret: ci-unit-test-secret
 
-      - name: Run unit tests
+      - name: Run unit and script tests
         run: pnpm test:unit:coverage
-
-      - name: Run script tests
-        run: pnpm test:scripts -- --run
 
       - name: Upload base coverage artifact
         if: github.ref == 'refs/heads/dev'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:
@@ -61,11 +61,38 @@ jobs:
       - name: Run script tests
         run: pnpm test:scripts -- --run
 
+      - name: Upload base coverage artifact
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-summary-dev
+          path: coverage/coverage-summary.json
+          retention-days: 90
+
+      - name: Download base coverage from dev
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        id: base-coverage
+        run: |
+          RUN_ID=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?branch=dev&status=success&per_page=1" \
+            --jq '.workflow_runs[0].id // empty')
+          if [ -n "$RUN_ID" ]; then
+            gh run download "$RUN_ID" \
+              --name coverage-summary-dev \
+              --dir /tmp/base-coverage \
+              --repo "${{ github.repository }}"
+            echo "path=/tmp/base-coverage/coverage-summary.json" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Post coverage report
         if: always()
         run: pnpm coverage:report
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_COVERAGE_SUMMARY_PATH: ${{ steps.base-coverage.outputs.path }}
 
   integration-tests:
     name: Integration tests

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:unit": "vitest --project unit",
     "test:integration": "vitest --project integration",
     "test:scripts": "vitest --project scripts",
-    "test:unit:coverage": "vitest run --project unit --coverage",
+    "test:unit:coverage": "vitest run --project unit --project scripts --coverage",
     "test:coverage": "vitest run --coverage",
     "coverage:report": "tsx scripts/coverage-report.ts",
     "test:e2e": "node scripts/test-e2e.mjs",

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -294,7 +294,7 @@ export function deltaIcon(delta: number): string {
   return "🟡"
 }
 
-function renderTotalSection(total: FileSummary, baseTotal: FileSummary | null): string {
+export function renderTotalSection(total: FileSummary, baseTotal: FileSummary | null): string {
   if (!baseTotal) {
     const rows = METRICS.map((k) => ({ label: LABELS[k], ...total[k] }))
     return `<h3>Project total</h3>\n${htmlTable(rows)}`

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -317,6 +317,12 @@ function renderFileCoverage({
         ? `<a href="https://github.com/${repo}/blob/${sha}/${file}">${file}</a>`
         : `<code>${file}</code>`
     const uncovered = uncoveredMap.get(file) ?? []
+    const uncoveredLinks =
+      repo && sha
+        ? uncovered
+            .map((n) => `<a href="https://github.com/${repo}/blob/${sha}/${file}#L${n}">${n}</a>`)
+            .join(", ")
+        : uncovered.join(", ")
     rows.push(
       `  <tr>
    <td align="left">${fileLink}</td>
@@ -324,7 +330,7 @@ function renderFileCoverage({
    <td align="right">${cell("statements")}</td>
    <td align="right">${cell("functions")}</td>
    <td align="right">${cell("branches")}</td>
-   <td align="left">${uncovered.join(", ")}</td>
+   <td align="left">${uncoveredLinks}</td>
   </tr>`,
     )
   }
@@ -378,20 +384,6 @@ function renderReport({
     "<p>Lines added or modified in this PR.</p>",
     htmlTable(rows),
   ]
-  const withGaps = files.filter((f) => f.uncovered.length > 0)
-  if (withGaps.length > 0) {
-    const items = withGaps.map(
-      (f) => `  <li><code>${f.file}</code>: ${f.uncovered.join(", ")}</li>`,
-    )
-    parts.push(
-      "",
-      "<details><summary>Uncovered changed lines</summary>",
-      "<ul>",
-      ...items,
-      "</ul>",
-      "</details>",
-    )
-  }
   return parts.join("\n")
 }
 

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -222,7 +222,7 @@ export function computePatchCoverage(
 
 // ─── GitHub API ───────────────────────────────────────────────────────────────
 
-async function fetchChangedFiles({
+export async function fetchChangedFiles({
   repo,
   prNumber,
   token,
@@ -492,7 +492,7 @@ export async function upsertComment({
 
 // ─── Entry point ──────────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const finalPath = process.env.COVERAGE_FINAL_PATH ?? "coverage/coverage-final.json"
   const summaryPath = process.env.COVERAGE_SUMMARY_PATH ?? "coverage/coverage-summary.json"
   const root = process.env.GITHUB_WORKSPACE ?? process.cwd()

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -267,13 +267,15 @@ const TABLE_HEADER = `<table>
 const TABLE_FOOTER = ` </tbody>
 </table>`
 
-function statusIcon(pct: number): string {
+export function statusIcon(pct: number): string {
   if (pct >= 80) return "🟢"
   if (pct >= 60) return "🟡"
   return "🔴"
 }
 
-function htmlTable(rows: { label: string; pct: number; covered: number; total: number }[]): string {
+export function htmlTable(
+  rows: { label: string; pct: number; covered: number; total: number }[],
+): string {
   const rowHtml = rows
     .map(
       ({ label, pct, covered, total }) =>
@@ -332,7 +334,7 @@ export function renderTotalSection(total: FileSummary, baseTotal: FileSummary | 
   return `<h3>Project total</h3>\n${header}\n${bodyRows}\n${TABLE_FOOTER}`
 }
 
-function renderFileCoverage({
+export function renderFileCoverage({
   summaryJson,
   changedFiles,
   uncoveredMap,
@@ -390,7 +392,7 @@ ${rows.join("\n")}
   return `<details><summary>File Coverage</summary>\n${table}\n</details>`
 }
 
-function renderReport({
+export function renderReport({
   total,
   baseTotal,
   summaryJson,
@@ -428,7 +430,7 @@ function renderReport({
   return parts.join("\n")
 }
 
-async function fetchAllComments(
+export async function fetchAllComments(
   repo: string,
   prNumber: number,
   headers: Record<string, string>,
@@ -447,7 +449,7 @@ async function fetchAllComments(
   return all
 }
 
-async function upsertComment({
+export async function upsertComment({
   repo,
   prNumber,
   token,

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -288,9 +288,48 @@ function htmlTable(rows: { label: string; pct: number; covered: number; total: n
   return `${TABLE_HEADER}\n${rowHtml}\n${TABLE_FOOTER}`
 }
 
-function renderTotalSection(total: FileSummary): string {
-  const rows = METRICS.map((k) => ({ label: LABELS[k], ...total[k] }))
-  return `<h3>Project total</h3>\n${htmlTable(rows)}`
+function deltaIcon(delta: number): string {
+  if (delta > 0.001) return "🟢"
+  if (delta < -0.001) return "🔴"
+  return "🟡"
+}
+
+function renderTotalSection(total: FileSummary, baseTotal: FileSummary | null): string {
+  if (!baseTotal) {
+    const rows = METRICS.map((k) => ({ label: LABELS[k], ...total[k] }))
+    return `<h3>Project total</h3>\n${htmlTable(rows)}`
+  }
+
+  const header = `<table>
+ <thead><tr>
+  <th align="center">Status</th>
+  <th align="left">Category</th>
+  <th align="right">Percentage</th>
+  <th align="right">Covered / Total</th>
+  <th align="right">Change</th>
+ </tr></thead>
+ <tbody>`
+
+  const bodyRows = METRICS.map((k) => {
+    const { pct, covered, total: tot } = total[k]
+    const delta = pct - baseTotal[k].pct
+    const icon = tot === 0 ? "🔵" : deltaIcon(delta)
+    const deltaStr =
+      tot === 0
+        ? "n/a"
+        : Math.abs(delta) <= 0.001
+          ? "±0.00%"
+          : `${delta > 0 ? "+" : ""}${delta.toFixed(2)}%`
+    return `  <tr>
+   <td align="center">${icon}</td>
+   <td align="left">${LABELS[k]}</td>
+   <td align="right">${tot === 0 ? "n/a" : `${pct.toFixed(2)}%`}</td>
+   <td align="right">${tot === 0 ? "n/a" : `${covered} / ${tot}`}</td>
+   <td align="right">${deltaStr}</td>
+  </tr>`
+  }).join("\n")
+
+  return `<h3>Project total</h3>\n${header}\n${bodyRows}\n${TABLE_FOOTER}`
 }
 
 function renderFileCoverage({
@@ -353,6 +392,7 @@ ${rows.join("\n")}
 
 function renderReport({
   total,
+  baseTotal,
   summaryJson,
   metrics,
   files,
@@ -361,6 +401,7 @@ function renderReport({
   sha,
 }: {
   total: FileSummary | null
+  baseTotal: FileSummary | null
   summaryJson: Record<string, FileSummary> | null
   metrics: MetricsWithPct
   files: { file: string; uncovered: number[] }[]
@@ -377,7 +418,7 @@ function renderReport({
   const parts = [
     COMMENT_MARKER,
     "<h2>Coverage Report</h2>",
-    ...(total ? ["", renderTotalSection(total)] : []),
+    ...(total ? ["", renderTotalSection(total, baseTotal)] : []),
     ...(fileCoverage ? ["", fileCoverage] : []),
     "",
     "<h3>Patch coverage</h3>",
@@ -480,6 +521,17 @@ async function main(): Promise<void> {
     )
   const total = summaryRaw?.total ?? null
 
+  const baseSummaryPath = process.env.BASE_COVERAGE_SUMMARY_PATH
+  const baseSummaryRaw: CoverageSummaryJson | null =
+    baseSummaryPath && existsSync(baseSummaryPath)
+      ? (JSON.parse(readFileSync(baseSummaryPath, "utf8")) as CoverageSummaryJson)
+      : null
+  if (baseSummaryPath && !baseSummaryRaw)
+    console.warn(
+      `${yellow("⚠")} BASE_COVERAGE_SUMMARY_PATH set but file not found — skipping delta.`,
+    )
+  const baseTotal = baseSummaryRaw?.total ?? null
+
   const repo = process.env.GITHUB_REPOSITORY
   const sha = process.env.GITHUB_SHA
   const token = process.env.GITHUB_TOKEN
@@ -506,6 +558,7 @@ async function main(): Promise<void> {
   const changedFiles = Object.keys(addedLinesByFile)
   const report = renderReport({
     total,
+    baseTotal,
     summaryJson: summaryByFile,
     metrics,
     files,

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -288,7 +288,7 @@ function htmlTable(rows: { label: string; pct: number; covered: number; total: n
   return `${TABLE_HEADER}\n${rowHtml}\n${TABLE_FOOTER}`
 }
 
-function deltaIcon(delta: number): string {
+export function deltaIcon(delta: number): string {
   if (delta > 0.001) return "🟢"
   if (delta < -0.001) return "🔴"
   return "🟡"

--- a/src/utilities/__tests__/formatAuthors.test.ts
+++ b/src/utilities/__tests__/formatAuthors.test.ts
@@ -27,6 +27,17 @@ describe("arrayToPlaintText", () => {
     expect(arrayToPlaintText(["Alice", "Bob"], "or")).toBe("Alice or Bob")
     expect(arrayToPlaintText(["Alice", "Bob", "Carol"], "or")).toBe("Alice, Bob or Carol")
   })
+
+  it("adds an Oxford comma for three or more items when requested", () => {
+    expect(arrayToPlaintText(["Alice", "Bob", "Carol"], "and", true)).toBe("Alice, Bob, and Carol")
+    expect(arrayToPlaintText(["Alice", "Bob", "Carol", "Dave"], "and", true)).toBe(
+      "Alice, Bob, Carol, and Dave",
+    )
+  })
+
+  it("does not add an Oxford comma for two items even when requested", () => {
+    expect(arrayToPlaintText(["Alice", "Bob"], "and", true)).toBe("Alice and Bob")
+  })
 })
 
 describe("arrayStringToPlainText", () => {

--- a/src/utilities/__tests__/formatAuthors.test.ts
+++ b/src/utilities/__tests__/formatAuthors.test.ts
@@ -14,6 +14,10 @@ describe("arrayToPlaintText", () => {
     expect(arrayToPlaintText(["Alice"])).toBe("Alice")
   })
 
+  it("returns empty string when the single item is undefined", () => {
+    expect(arrayToPlaintText([undefined as unknown as string])).toBe("")
+  })
+
   it("joins two items with the conjunction", () => {
     expect(arrayToPlaintText(["Alice", "Bob"])).toBe("Alice and Bob")
   })

--- a/src/utilities/__tests__/formatAuthors.test.ts
+++ b/src/utilities/__tests__/formatAuthors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import { arrayStringToPlainText, arrayToPlaintText } from "../formatAuthors"
+
+describe("arrayToPlaintText", () => {
+  it("returns empty string for an empty list", () => {
+    expect(arrayToPlaintText([])).toBe("")
+  })
+
+  it("returns the single item for a one-element list", () => {
+    expect(arrayToPlaintText(["Alice"])).toBe("Alice")
+  })
+
+  it("joins two items with the conjunction", () => {
+    expect(arrayToPlaintText(["Alice", "Bob"])).toBe("Alice and Bob")
+  })
+
+  it("joins three items with commas and a trailing conjunction", () => {
+    expect(arrayToPlaintText(["Alice", "Bob", "Carol"])).toBe("Alice, Bob and Carol")
+  })
+
+  it("joins four items correctly", () => {
+    expect(arrayToPlaintText(["Alice", "Bob", "Carol", "Dave"])).toBe("Alice, Bob, Carol and Dave")
+  })
+
+  it("respects a custom conjunction", () => {
+    expect(arrayToPlaintText(["Alice", "Bob"], "or")).toBe("Alice or Bob")
+    expect(arrayToPlaintText(["Alice", "Bob", "Carol"], "or")).toBe("Alice, Bob or Carol")
+  })
+})
+
+describe("arrayStringToPlainText", () => {
+  it("splits a comma-separated string and joins with conjunction", () => {
+    expect(arrayStringToPlainText("Alice,Bob,Carol")).toBe("Alice, Bob and Carol")
+  })
+
+  it("respects a custom separator", () => {
+    expect(arrayStringToPlainText("Alice|Bob", "|")).toBe("Alice and Bob")
+  })
+})

--- a/src/utilities/__tests__/formatAuthors.test.ts
+++ b/src/utilities/__tests__/formatAuthors.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { arrayStringToPlainText, arrayToPlaintText } from "../formatAuthors"
+import { arrayStringToPlainText, arrayToPlaintText, formatAuthors } from "../formatAuthors"
+
+type Author = Parameters<typeof formatAuthors>[0][number]
+const author = (name: string): Author => ({ name }) as Author
 
 describe("arrayToPlaintText", () => {
   it("returns empty string for an empty list", () => {
@@ -37,6 +40,30 @@ describe("arrayToPlaintText", () => {
 
   it("does not add an Oxford comma for two items even when requested", () => {
     expect(arrayToPlaintText(["Alice", "Bob"], "and", true)).toBe("Alice and Bob")
+  })
+})
+
+describe("formatAuthors", () => {
+  it("returns empty string for no authors", () => {
+    expect(formatAuthors([])).toBe("")
+  })
+
+  it("formats a single author", () => {
+    expect(formatAuthors([author("Alice")])).toBe("Alice")
+  })
+
+  it("formats two authors", () => {
+    expect(formatAuthors([author("Alice"), author("Bob")])).toBe("Alice and Bob")
+  })
+
+  it("formats three authors", () => {
+    expect(formatAuthors([author("Alice"), author("Bob"), author("Carol")])).toBe(
+      "Alice, Bob and Carol",
+    )
+  })
+
+  it("filters out authors with no name", () => {
+    expect(formatAuthors([author("Alice"), { name: null } as Author])).toBe("Alice")
   })
 })
 

--- a/src/utilities/formatAuthors.ts
+++ b/src/utilities/formatAuthors.ts
@@ -36,3 +36,12 @@ export const formatAuthors = (
   const authorNames = authors.map((author) => author.name).filter(Boolean) as string[]
   return arrayToPlaintText(authorNames)
 }
+
+/** Returns "By Author" or "By Author1 and Author2" etc., prefixed with "By ". */
+export function formatAuthorsByline(
+  authors: NonNullable<NonNullable<Article["populatedAuthors"]>[number]>[],
+): string {
+  const names = formatAuthors(authors)
+  if (!names) return ""
+  return `By ${names}`
+}

--- a/src/utilities/formatAuthors.ts
+++ b/src/utilities/formatAuthors.ts
@@ -36,12 +36,3 @@ export const formatAuthors = (
   const authorNames = authors.map((author) => author.name).filter(Boolean) as string[]
   return arrayToPlaintText(authorNames)
 }
-
-/** Returns "By Author" or "By Author1 and Author2" etc., prefixed with "By ". */
-export function formatAuthorsByline(
-  authors: NonNullable<NonNullable<Article["populatedAuthors"]>[number]>[],
-): string {
-  const names = formatAuthors(authors)
-  if (!names) return ""
-  return `By ${names}`
-}

--- a/src/utilities/formatAuthors.ts
+++ b/src/utilities/formatAuthors.ts
@@ -1,11 +1,18 @@
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { Article } from "@/payload-types"
 
-export function arrayToPlaintText(list: string[], conjunction = "and"): string {
+export function arrayToPlaintText(
+  list: string[],
+  conjunction = "and",
+  oxfordComma = false,
+): string {
   if (!list.length) return ""
   if (list.length === 1) return list[0] ?? ""
   if (list.length === 2) return `${list[0]} ${conjunction} ${list[1]}`
-  return `${list.slice(0, -1).join(", ")} ${conjunction} ${list[list.length - 1]}`
+  const tail = oxfordComma
+    ? `, ${conjunction} ${list[list.length - 1]}`
+    : ` ${conjunction} ${list[list.length - 1]}`
+  return `${list.slice(0, -1).join(", ")}${tail}`
 }
 
 export function arrayStringToPlainText(list: string, sep = ",", conjunction = "and"): string {

--- a/tests/scripts/coverage-report.test.ts
+++ b/tests/scripts/coverage-report.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   computeFileMetrics,
   computePatchCoverage,
+  deltaIcon,
   indexCoverageByFile,
   parseAddedLines,
 } from "../../scripts/coverage-report"
@@ -65,6 +66,24 @@ describe("computeFileMetrics", () => {
   it("ignores changed lines outside the file's coverage map", () => {
     const { counts } = computeFileMetrics(fileCoverage, new Set([99]))
     for (const m of Object.values(counts)) expect(m.total).toBe(0)
+  })
+})
+
+describe("deltaIcon", () => {
+  it("returns 🟢 when coverage improved", () => {
+    expect(deltaIcon(0.5)).toBe("🟢")
+    expect(deltaIcon(0.002)).toBe("🟢") // just above threshold
+  })
+
+  it("returns 🔴 when coverage worsened", () => {
+    expect(deltaIcon(-0.5)).toBe("🔴")
+    expect(deltaIcon(-0.002)).toBe("🔴") // just below threshold
+  })
+
+  it("returns 🟡 when coverage is unchanged within floating-point noise", () => {
+    expect(deltaIcon(0)).toBe("🟡")
+    expect(deltaIcon(0.001)).toBe("🟡") // at threshold, not beyond
+    expect(deltaIcon(-0.001)).toBe("🟡") // at threshold, not beyond
   })
 })
 

--- a/tests/scripts/coverage-report.test.ts
+++ b/tests/scripts/coverage-report.test.ts
@@ -1,18 +1,32 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   computeFileMetrics,
   computePatchCoverage,
   deltaIcon,
+  fetchAllComments,
+  htmlTable,
   indexCoverageByFile,
   parseAddedLines,
+  renderFileCoverage,
+  renderReport,
   renderTotalSection,
+  statusIcon,
+  upsertComment,
 } from "../../scripts/coverage-report"
 
 // Minimal FileSummary fixture
 function summary(pct: number, covered = Math.round(pct), total = 100) {
   const m = { total, covered, skipped: 0, pct }
   return { lines: m, statements: m, functions: m, branches: m }
+}
+
+// Zero-coverage MetricsWithPct fixture for renderReport
+const emptyMetrics = {
+  lines: { covered: 0, total: 0, pct: 100 },
+  statements: { covered: 0, total: 0, pct: 100 },
+  functions: { covered: 0, total: 0, pct: 100 },
+  branches: { covered: 0, total: 0, pct: 100 },
 }
 
 // A synthetic istanbul file-coverage object:
@@ -128,6 +142,181 @@ describe("renderTotalSection", () => {
   })
 })
 
+describe("statusIcon", () => {
+  it("returns 🟢 at or above 80%", () => {
+    expect(statusIcon(100)).toBe("🟢")
+    expect(statusIcon(80)).toBe("🟢")
+  })
+
+  it("returns 🟡 between 60% and 79%", () => {
+    expect(statusIcon(79)).toBe("🟡")
+    expect(statusIcon(60)).toBe("🟡")
+  })
+
+  it("returns 🔴 below 60%", () => {
+    expect(statusIcon(59)).toBe("🔴")
+    expect(statusIcon(0)).toBe("🔴")
+  })
+})
+
+describe("htmlTable", () => {
+  it("renders a row with percentage and covered/total", () => {
+    const html = htmlTable([{ label: "Lines", pct: 85, covered: 85, total: 100 }])
+    expect(html).toContain("🟢")
+    expect(html).toContain("85.00%")
+    expect(html).toContain("85 / 100")
+    expect(html).toContain("Lines")
+  })
+
+  it("renders n/a and 🔵 for rows with no coverable items", () => {
+    const html = htmlTable([{ label: "Functions", pct: 0, covered: 0, total: 0 }])
+    expect(html).toContain("🔵")
+    expect(html).toContain("n/a")
+    expect(html).not.toContain("0.00%")
+  })
+})
+
+describe("renderFileCoverage", () => {
+  const fileSummary = summary(78, 7, 9)
+  const summaryJson = { "src/foo.ts": fileSummary }
+
+  it("returns null when no changed files have coverage data", () => {
+    expect(
+      renderFileCoverage({
+        summaryJson,
+        changedFiles: ["src/untracked.ts"],
+        uncoveredMap: new Map(),
+        repo: undefined,
+        sha: undefined,
+      }),
+    ).toBeNull()
+  })
+
+  it("renders a file row with plain code tag when repo/sha are absent", () => {
+    const html = renderFileCoverage({
+      summaryJson,
+      changedFiles: ["src/foo.ts"],
+      uncoveredMap: new Map(),
+      repo: undefined,
+      sha: undefined,
+    })
+    expect(html).toContain("<code>src/foo.ts</code>")
+    expect(html).toContain("File Coverage")
+  })
+
+  it("renders a file link when repo and sha are provided", () => {
+    const html = renderFileCoverage({
+      summaryJson,
+      changedFiles: ["src/foo.ts"],
+      uncoveredMap: new Map(),
+      repo: "owner/repo",
+      sha: "abc123",
+    })
+    expect(html).toContain(
+      `<a href="https://github.com/owner/repo/blob/abc123/src/foo.ts">src/foo.ts</a>`,
+    )
+  })
+
+  it("renders uncovered lines as plain numbers without repo/sha", () => {
+    const html = renderFileCoverage({
+      summaryJson,
+      changedFiles: ["src/foo.ts"],
+      uncoveredMap: new Map([["src/foo.ts", [10, 20]]]),
+      repo: undefined,
+      sha: undefined,
+    })
+    expect(html).toContain("10, 20")
+    expect(html).not.toContain("<a href")
+  })
+
+  it("renders uncovered lines as GitHub links when repo and sha are provided", () => {
+    const html = renderFileCoverage({
+      summaryJson,
+      changedFiles: ["src/foo.ts"],
+      uncoveredMap: new Map([["src/foo.ts", [42]]]),
+      repo: "owner/repo",
+      sha: "abc123",
+    })
+    expect(html).toContain(
+      `<a href="https://github.com/owner/repo/blob/abc123/src/foo.ts#L42">42</a>`,
+    )
+  })
+})
+
+describe("renderReport", () => {
+  it("always includes the comment marker and patch coverage section", () => {
+    const html = renderReport({
+      total: null,
+      baseTotal: null,
+      summaryJson: null,
+      metrics: emptyMetrics,
+      files: [],
+      changedFiles: [],
+      repo: undefined,
+      sha: undefined,
+    })
+    expect(html).toContain("<!-- coverage-report -->")
+    expect(html).toContain("Patch coverage")
+  })
+
+  it("omits the project total section when total is null", () => {
+    const html = renderReport({
+      total: null,
+      baseTotal: null,
+      summaryJson: null,
+      metrics: emptyMetrics,
+      files: [],
+      changedFiles: [],
+      repo: undefined,
+      sha: undefined,
+    })
+    expect(html).not.toContain("Project total")
+  })
+
+  it("includes the project total section when total is provided", () => {
+    const html = renderReport({
+      total: summary(75),
+      baseTotal: null,
+      summaryJson: null,
+      metrics: emptyMetrics,
+      files: [],
+      changedFiles: [],
+      repo: undefined,
+      sha: undefined,
+    })
+    expect(html).toContain("Project total")
+  })
+
+  it("includes the file coverage section when changed files have summary data", () => {
+    const html = renderReport({
+      total: summary(75),
+      baseTotal: null,
+      summaryJson: { "src/foo.ts": summary(78) },
+      metrics: emptyMetrics,
+      files: [],
+      changedFiles: ["src/foo.ts"],
+      repo: undefined,
+      sha: undefined,
+    })
+    expect(html).toContain("File Coverage")
+    expect(html).toContain("src/foo.ts")
+  })
+
+  it("omits the file coverage section when no changed files have summary data", () => {
+    const html = renderReport({
+      total: summary(75),
+      baseTotal: null,
+      summaryJson: { "src/foo.ts": summary(78) },
+      metrics: emptyMetrics,
+      files: [],
+      changedFiles: ["src/untracked.ts"],
+      repo: undefined,
+      sha: undefined,
+    })
+    expect(html).not.toContain("File Coverage")
+  })
+})
+
 describe("computePatchCoverage", () => {
   it("aggregates metrics and computes percentages", () => {
     const result = computePatchCoverage(
@@ -147,5 +336,94 @@ describe("computePatchCoverage", () => {
     expect(result.metrics.lines.total).toBe(0)
     expect(result.metrics.lines.pct).toBe(100)
     expect(result.files).toEqual([])
+  })
+})
+
+// ─── GitHub API helpers ────────────────────────────────────────────────────────
+
+function mockRes(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body, text: async () => JSON.stringify(body) }
+}
+
+describe("fetchAllComments", () => {
+  const headers = { Authorization: "Bearer token" }
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn())
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("returns comments from a single page", async () => {
+    const comments = [{ id: 1, body: "hello" }]
+    vi.mocked(fetch).mockResolvedValueOnce(mockRes(comments) as Response)
+    const result = await fetchAllComments("owner/repo", 42, headers)
+    expect(result).toEqual(comments)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("paginates until a page returns fewer than 100 comments", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ id: i }))
+    const page2 = [{ id: 100, body: "last" }]
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockRes(page1) as Response)
+      .mockResolvedValueOnce(mockRes(page2) as Response)
+    const result = await fetchAllComments("owner/repo", 1, headers)
+    expect(result).toHaveLength(101)
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("throws on a non-ok response", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockRes("Not Found", false, 404) as Response)
+    await expect(fetchAllComments("owner/repo", 1, headers)).rejects.toThrow("GitHub API 404")
+  })
+})
+
+describe("upsertComment", () => {
+  const base = { repo: "owner/repo", prNumber: 7, token: "tok", body: "<!-- coverage-report -->" }
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn())
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("POSTs a new comment when none exists", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockRes([]) as Response) // fetchAllComments page 1
+      .mockResolvedValueOnce(mockRes({}) as Response) // POST
+    await upsertComment(base)
+    const [, postCall] = vi.mocked(fetch).mock.calls
+    expect((postCall![1] as RequestInit).method).toBe("POST")
+    expect(postCall![0] as string).toContain(`/issues/${base.prNumber}/comments`)
+  })
+
+  it("PATCHes an existing comment when the marker is found", async () => {
+    const existing = [{ id: 99, body: "<!-- coverage-report --> old content" }]
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockRes(existing) as Response)
+      .mockResolvedValueOnce(mockRes({}) as Response) // PATCH
+    await upsertComment(base)
+    const [, patchCall] = vi.mocked(fetch).mock.calls
+    expect((patchCall![1] as RequestInit).method).toBe("PATCH")
+    expect(patchCall![0] as string).toContain(`/comments/99`)
+  })
+
+  it("DELETEs stale comments before posting", async () => {
+    const stale = [{ id: 55, body: "<!-- patch-coverage-report --> stale" }]
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockRes(stale) as Response) // fetchAllComments
+      .mockResolvedValueOnce(mockRes({}) as Response) // DELETE stale
+      .mockResolvedValueOnce(mockRes({}) as Response) // POST new
+    await upsertComment(base)
+    const [, deleteCall, postCall] = vi.mocked(fetch).mock.calls
+    expect((deleteCall![1] as RequestInit).method).toBe("DELETE")
+    expect(deleteCall![0] as string).toContain(`/comments/55`)
+    expect((postCall![1] as RequestInit).method).toBe("POST")
+  })
+
+  it("throws when the final POST/PATCH fails", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockRes([]) as Response)
+      .mockResolvedValueOnce(mockRes("Forbidden", false, 403) as Response)
+    await expect(upsertComment(base)).rejects.toThrow("GitHub API 403")
   })
 })

--- a/tests/scripts/coverage-report.test.ts
+++ b/tests/scripts/coverage-report.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
@@ -5,8 +9,10 @@ import {
   computePatchCoverage,
   deltaIcon,
   fetchAllComments,
+  fetchChangedFiles,
   htmlTable,
   indexCoverageByFile,
+  main,
   parseAddedLines,
   renderFileCoverage,
   renderReport,
@@ -63,6 +69,11 @@ describe("parseAddedLines", () => {
 
   it("returns an empty set for an empty patch", () => {
     expect(parseAddedLines("").size).toBe(0)
+  })
+
+  it("ignores lines before the first hunk header", () => {
+    const patch = ["--- a/src/foo.ts", "+++ b/src/foo.ts", "@@ -1,1 +1,2 @@", "+added"].join("\n")
+    expect([...parseAddedLines(patch)]).toEqual([1])
   })
 })
 
@@ -240,6 +251,25 @@ describe("renderFileCoverage", () => {
     expect(html).toContain(
       `<a href="https://github.com/owner/repo/blob/abc123/src/foo.ts#L42">42</a>`,
     )
+  })
+
+  it("renders n/a for a metric whose total is zero", () => {
+    const zeroFunctions = {
+      "src/foo.ts": {
+        lines: { total: 9, covered: 7, skipped: 0, pct: 78 },
+        statements: { total: 13, covered: 10, skipped: 0, pct: 77 },
+        functions: { total: 0, covered: 0, skipped: 0, pct: 100 },
+        branches: { total: 14, covered: 13, skipped: 0, pct: 93 },
+      },
+    }
+    const html = renderFileCoverage({
+      summaryJson: zeroFunctions,
+      changedFiles: ["src/foo.ts"],
+      uncoveredMap: new Map(),
+      repo: undefined,
+      sha: undefined,
+    })
+    expect(html).toContain("n/a")
   })
 })
 
@@ -425,5 +455,106 @@ describe("upsertComment", () => {
       .mockResolvedValueOnce(mockRes([]) as Response)
       .mockResolvedValueOnce(mockRes("Forbidden", false, 403) as Response)
     await expect(upsertComment(base)).rejects.toThrow("GitHub API 403")
+  })
+
+  it("warns but continues when a stale comment DELETE fails", async () => {
+    const stale = [{ id: 55, body: "<!-- patch-coverage-report --> stale" }]
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockRes(stale) as Response) // fetchAllComments
+      .mockResolvedValueOnce(mockRes("Forbidden", false, 403) as Response) // DELETE fails
+      .mockResolvedValueOnce(mockRes({}) as Response) // POST still succeeds
+    await expect(upsertComment(base)).resolves.toBeUndefined()
+  })
+})
+
+describe("fetchChangedFiles", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn())
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("returns added lines keyed by filename", async () => {
+    const files = [
+      { status: "modified", patch: "@@ -1,1 +1,2 @@\n+new line", filename: "src/a.ts" },
+    ]
+    vi.mocked(fetch).mockResolvedValueOnce(mockRes(files) as Response)
+    const result = await fetchChangedFiles({ repo: "owner/repo", prNumber: 1, token: "tok" })
+    expect(result["src/a.ts"]).toBeDefined()
+    expect(result["src/a.ts"]!.has(1)).toBe(true)
+  })
+
+  it("skips removed files", async () => {
+    const files = [{ status: "removed", patch: "@@ -1,1 +0,0 @@\n-gone", filename: "src/gone.ts" }]
+    vi.mocked(fetch).mockResolvedValueOnce(mockRes(files) as Response)
+    const result = await fetchChangedFiles({ repo: "owner/repo", prNumber: 1, token: undefined })
+    expect(Object.keys(result)).toHaveLength(0)
+  })
+
+  it("skips files without a patch (e.g. binary files)", async () => {
+    const files = [{ status: "modified", filename: "image.png" }]
+    vi.mocked(fetch).mockResolvedValueOnce(mockRes(files) as Response)
+    const result = await fetchChangedFiles({ repo: "owner/repo", prNumber: 1, token: undefined })
+    expect(Object.keys(result)).toHaveLength(0)
+  })
+
+  it("omits the Authorization header when no token is provided", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockRes([]) as Response)
+    await fetchChangedFiles({ repo: "owner/repo", prNumber: 1, token: undefined })
+    const headers = vi.mocked(fetch).mock.calls[0]![1]!.headers as Record<string, string>
+    expect(headers["Authorization"]).toBeUndefined()
+  })
+
+  it("paginates through multiple pages", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      status: "modified",
+      patch: "@@ -1,1 +1,1 @@\n+x",
+      filename: `src/f${i}.ts`,
+    }))
+    const page2 = [{ status: "modified", patch: "@@ -1,1 +1,1 @@\n+x", filename: "src/last.ts" }]
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(mockRes(page1) as Response)
+      .mockResolvedValueOnce(mockRes(page2) as Response)
+    const result = await fetchChangedFiles({ repo: "owner/repo", prNumber: 1, token: "tok" })
+    expect(Object.keys(result)).toHaveLength(101)
+  })
+
+  it("throws on a non-ok response", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(mockRes("Not Found", false, 404) as Response)
+    await expect(
+      fetchChangedFiles({ repo: "owner/repo", prNumber: 1, token: "tok" }),
+    ).rejects.toThrow("GitHub API 404")
+  })
+})
+
+describe("main", () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "coverage-main-test-"))
+  })
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true })
+    delete process.env.GITHUB_EVENT_PATH
+    delete process.env.COVERAGE_FINAL_PATH
+  })
+
+  it("exits early when there is no pull_request in the event", async () => {
+    delete process.env.GITHUB_EVENT_PATH
+    await expect(main()).resolves.toBeUndefined()
+  })
+
+  it("exits early when the event has no pull_request number", async () => {
+    const eventPath = join(tmpDir, "event.json")
+    writeFileSync(eventPath, JSON.stringify({ push: {} }))
+    process.env.GITHUB_EVENT_PATH = eventPath
+    await expect(main()).resolves.toBeUndefined()
+  })
+
+  it("exits early when coverage-final.json does not exist", async () => {
+    const eventPath = join(tmpDir, "event.json")
+    writeFileSync(eventPath, JSON.stringify({ pull_request: { number: 42 } }))
+    process.env.GITHUB_EVENT_PATH = eventPath
+    process.env.COVERAGE_FINAL_PATH = join(tmpDir, "nonexistent.json")
+    await expect(main()).resolves.toBeUndefined()
   })
 })

--- a/tests/scripts/coverage-report.test.ts
+++ b/tests/scripts/coverage-report.test.ts
@@ -6,7 +6,14 @@ import {
   deltaIcon,
   indexCoverageByFile,
   parseAddedLines,
+  renderTotalSection,
 } from "../../scripts/coverage-report"
+
+// Minimal FileSummary fixture
+function summary(pct: number, covered = Math.round(pct), total = 100) {
+  const m = { total, covered, skipped: 0, pct }
+  return { lines: m, statements: m, functions: m, branches: m }
+}
 
 // A synthetic istanbul file-coverage object:
 //  line 1 — statement ran (1)         → covered
@@ -84,6 +91,40 @@ describe("deltaIcon", () => {
     expect(deltaIcon(0)).toBe("🟡")
     expect(deltaIcon(0.001)).toBe("🟡") // at threshold, not beyond
     expect(deltaIcon(-0.001)).toBe("🟡") // at threshold, not beyond
+  })
+})
+
+describe("renderTotalSection", () => {
+  it("renders absolute-threshold dots when no base is provided", () => {
+    const html = renderTotalSection(summary(85), null)
+    expect(html).toContain("🟢") // 85% ≥ 80
+    expect(html).not.toContain("Change")
+  })
+
+  it("shows 🟢 and a positive delta when coverage improved", () => {
+    const html = renderTotalSection(summary(85), summary(80))
+    expect(html).toContain("🟢")
+    expect(html).toContain("+5.00%")
+    expect(html).toContain("Change")
+  })
+
+  it("shows 🔴 and a negative delta when coverage worsened", () => {
+    const html = renderTotalSection(summary(75), summary(80))
+    expect(html).toContain("🔴")
+    expect(html).toContain("-5.00%")
+  })
+
+  it("shows 🟡 and ±0.00% when coverage is unchanged", () => {
+    const html = renderTotalSection(summary(80), summary(80))
+    expect(html).toContain("🟡")
+    expect(html).toContain("±0.00%")
+  })
+
+  it("shows 🔵 and n/a for metrics with no coverable lines", () => {
+    const html = renderTotalSection(summary(0, 0, 0), summary(0, 0, 0))
+    expect(html).toContain("🔵")
+    // every data cell should be n/a
+    expect(html.match(/n\/a/g)?.length).toBeGreaterThanOrEqual(4)
   })
 })
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,7 +13,7 @@ export default defineConfig({
       // Instrument the whole source tree so the "total" reflects the real project
       // coverage. Without `include`, Vitest 4 only reports files imported during the
       // run (the handful the tests touch), making the total read like patch coverage.
-      include: ["src/**/*.{ts,tsx}"],
+      include: ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
       exclude: [
         "**/__tests__/**",
         "**/*.{test,spec}.{ts,tsx}",
@@ -24,7 +24,6 @@ export default defineConfig({
         "src/payload.config.ts",
         "**/*.config.{ts,mts,js,mjs,cjs}",
         "tests/**",
-        "scripts/**",
       ],
     },
     projects: [


### PR DESCRIPTION
## Summary

- Removes the redundant "Uncovered changed lines" details block — the same data is already visible in the File Coverage table's Uncovered column
- Makes uncovered line numbers in the File Coverage table clickable links to the exact line on GitHub
- Adds delta-relative status dots to the Project total section (🟢 improved / 🔴 worsened / 🟡 flat vs the `dev` branch baseline), with a "Change" column showing the numeric delta
- Exports `deltaIcon` and adds unit tests covering all three delta outcomes

## How the delta works

On every push to `dev`, CI uploads `coverage-summary.json` as the `coverage-summary-dev` artifact. On PR runs, CI downloads the latest successful `dev` artifact and passes it to the report script via `BASE_COVERAGE_SUMMARY_PATH`. When the baseline is present the Project total table gains a **Change** column and status dots reflect direction rather than absolute thresholds.

> **Note:** The delta column will not appear until CI has run at least once on `dev` after this PR merges. Until then the Project total falls back to absolute threshold dots (🟢 ≥ 80% / 🟡 ≥ 60% / 🔴 < 60%). Patch coverage and File Coverage are unaffected — those show real numbers on every PR run.

## Test plan

- [x] Patch coverage shows 🟢 100% for newly added/modified lines in `src/`
- [x] File Coverage section lists changed source files with per-file metrics
- [x] Uncovered line numbers in File Coverage link to the correct GitHub line anchor
- [ ] After `dev` receives a CI run, Project total shows a Change column with delta dots

https://claude.ai/code/session_01NJigxsKUXEs6Zc3YTuwFd6