### PR TITLE
Remove unused path resolution logic from vitest config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     ],
     "paths": {
       "@payload-config": ["./src/payload.config.ts"],
-      "react": ["./node_modules/@types/react"],
       "@/*": ["./src/*"]
     }
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,9 +1,5 @@
 import react from "@vitejs/plugin-react"
-import path from "path"
-import { fileURLToPath } from "url"
 import { defineConfig } from "vitest/config"
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   test: {
@@ -38,12 +34,7 @@ export default defineConfig({
         },
       },
       {
-        resolve: {
-          tsconfigPaths: true,
-          // tsconfig maps "react" → @types/react for type-checking, but that package has
-          // no runtime exports. Override it here so Vite resolves to the actual runtime package.
-          alias: { react: path.resolve(__dirname, "node_modules/react") },
-        },
+        resolve: { tsconfigPaths: true },
         test: {
           name: "integration",
           environment: "node",


### PR DESCRIPTION
## Context

This PR removes unused path resolution utilities and a custom React alias configuration from the vitest config. The `__dirname` variable and related imports (`path` and `fileURLToPath`) were being used only for a React module alias that is no longer necessary. The tsconfig.json path mapping for React has also been removed as it's no longer needed.

The changes simplify the configuration by relying on Vite's default module resolution behavior instead of explicitly aliasing React to the runtime package.

## Test Plan

Existing vitest tests should continue to pass with the default module resolution. The integration tests in particular should verify that React modules are correctly resolved without the explicit alias configuration.

https://claude.ai/code/session_011BCsNDNdrC9qZqyYt3pHcF