### PR TITLE
test: filter PR screenshots to only show snapshots changed in the PR

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -88,7 +88,7 @@ jobs:
           git -C /tmp/assets push "$remote" "$ASSETS_BRANCH"
 
       - name: Upload screenshots to PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,6 +50,43 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
+      - name: Publish screenshot baseline (main)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          ASSETS_BRANCH: pr-screenshots
+        run: |
+          if [ ! -d screenshots ] || [ -z "$(ls screenshots/*.png 2>/dev/null)" ]; then
+            echo "No screenshots found — skipping baseline update."
+            exit 0
+          fi
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          remote="https://x-access-token:${GH_TOKEN}@github.com/$OWNER/$REPO.git"
+
+          if git ls-remote --exit-code "$remote" "refs/heads/$ASSETS_BRANCH" >/dev/null 2>&1; then
+            git clone --depth=1 --branch "$ASSETS_BRANCH" "$remote" /tmp/assets
+          else
+            git clone --depth=1 "$remote" /tmp/assets
+            git -C /tmp/assets checkout --orphan "$ASSETS_BRANCH"
+            git -C /tmp/assets rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          rm -rf /tmp/assets/main
+          mkdir -p /tmp/assets/main
+          cp screenshots/*.png /tmp/assets/main/
+          git -C /tmp/assets add main
+          if git -C /tmp/assets diff --cached --quiet; then
+            echo "Baseline unchanged."
+            exit 0
+          fi
+          git -C /tmp/assets commit -m "screenshots: baseline @ ${GITHUB_SHA}"
+          git -C /tmp/assets push "$remote" "$ASSETS_BRANCH"
+
       - name: Upload screenshots to PR comment
         if: github.event_name == 'pull_request'
         env:
@@ -80,14 +117,36 @@ jobs:
             git -C /tmp/assets rm -rf . >/dev/null 2>&1 || true
           fi
 
+          # Filter to only new or changed screenshots vs the main baseline
+          mkdir -p /tmp/changed
+          for f in screenshots/*.png; do
+            name=$(basename "$f")
+            baseline="/tmp/assets/main/$name"
+            if [ ! -f "$baseline" ] || ! cmp -s "$f" "$baseline"; then
+              cp "$f" "/tmp/changed/$name"
+            fi
+          done
+
+          if [ -z "$(ls /tmp/changed/*.png 2>/dev/null)" ]; then
+            echo "No new or changed screenshots — skipping comment."
+            # Remove a stale screenshots comment if one exists
+            comment_id=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+              --jq '[.[] | select(.body | startswith("<!-- screenshots -->"))] | first | .id // empty')
+            if [ -n "$comment_id" ]; then
+              gh api --method DELETE "repos/$OWNER/$REPO/issues/comments/$comment_id"
+              echo "Removed stale screenshots comment."
+            fi
+            exit 0
+          fi
+
           mkdir -p "/tmp/assets/$asset_dir"
-          cp screenshots/*.png "/tmp/assets/$asset_dir/"
+          cp /tmp/changed/*.png "/tmp/assets/$asset_dir/"
           git -C /tmp/assets add "$asset_dir"
           git -C /tmp/assets commit -m "screenshots: PR #$PR_NUMBER @ $PR_SHA"
           git -C /tmp/assets push "$remote" "$ASSETS_BRANCH"
 
           images=""
-          for f in screenshots/*.png; do
+          for f in /tmp/changed/*.png; do
             name=$(basename "$f" .png)
             url="https://raw.githubusercontent.com/$OWNER/$REPO/$ASSETS_BRANCH/$asset_dir/$name.png"
             images="$images\n**$name**\n![$name]($url)\n"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,7 @@ name: Playwright Tests
 
 on:
   push:
-    branches: [main, dev]
+    branches: [dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-  workflow_dispatch:
-    inputs:
-      update_snapshots:
-        description: "Regenerate visual snapshots and commit them to this branch"
-        type: boolean
-        default: false
 
 jobs:
   test:
@@ -49,27 +43,7 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium firefox webkit
 
       - name: Run Playwright tests
-        if: ${{ !inputs.update_snapshots }}
         run: pnpm test:e2e
-
-      - name: Regenerate visual snapshots
-        if: ${{ inputs.update_snapshots }}
-        run: pnpm test:e2e -- --update-snapshots --project=chromium
-
-      - name: Commit regenerated snapshots
-        if: ${{ inputs.update_snapshots }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add tests/e2e/__screenshots__
-          if git diff --cached --quiet; then
-            echo "No snapshot changes to commit."
-            exit 0
-          fi
-          git commit -m "test: update e2e visual snapshots"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
 
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main, dev]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      update_snapshots:
+        description: "Regenerate visual snapshots and commit them to this branch"
+        type: boolean
+        default: false
 
 jobs:
   test:
@@ -43,7 +49,27 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium firefox webkit
 
       - name: Run Playwright tests
+        if: ${{ !inputs.update_snapshots }}
         run: pnpm test:e2e
+
+      - name: Regenerate visual snapshots
+        if: ${{ inputs.update_snapshots }}
+        run: pnpm test:e2e -- --update-snapshots --project=chromium
+
+      - name: Commit regenerated snapshots
+        if: ${{ inputs.update_snapshots }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add tests/e2e/__screenshots__
+          if git diff --cached --quiet; then
+            echo "No snapshot changes to commit."
+            exit 0
+          fi
+          git commit -m "test: update e2e visual snapshots"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
 
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,7 @@ name: Playwright Tests
 
 on:
   push:
-    branches: [dev]
+    branches: [main, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js environment
         uses: ./.github/actions/setup-project
@@ -50,55 +52,32 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-      - name: Publish screenshot baseline (dev)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-          ASSETS_BRANCH: pr-screenshots
-        run: |
-          if [ ! -d screenshots ] || [ -z "$(ls screenshots/*.png 2>/dev/null)" ]; then
-            echo "No screenshots found — skipping baseline update."
-            exit 0
-          fi
-
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          remote="https://x-access-token:${GH_TOKEN}@github.com/$OWNER/$REPO.git"
-
-          if git ls-remote --exit-code "$remote" "refs/heads/$ASSETS_BRANCH" >/dev/null 2>&1; then
-            git clone --depth=1 --branch "$ASSETS_BRANCH" "$remote" /tmp/assets
-          else
-            git clone --depth=1 "$remote" /tmp/assets
-            git -C /tmp/assets checkout --orphan "$ASSETS_BRANCH"
-            git -C /tmp/assets rm -rf . >/dev/null 2>&1 || true
-          fi
-
-          rm -rf /tmp/assets/dev
-          mkdir -p /tmp/assets/dev
-          cp screenshots/*.png /tmp/assets/dev/
-          git -C /tmp/assets add dev
-          if git -C /tmp/assets diff --cached --quiet; then
-            echo "Baseline unchanged."
-            exit 0
-          fi
-          git -C /tmp/assets commit -m "screenshots: baseline @ ${GITHUB_SHA}"
-          git -C /tmp/assets push "$remote" "$ASSETS_BRANCH"
-
-      - name: Upload screenshots to PR comment
-        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main'
+      - name: Post snapshot updates to PR comment
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           ASSETS_BRANCH: pr-screenshots
         run: |
-          if [ ! -d screenshots ] || [ -z "$(ls screenshots/*.png 2>/dev/null)" ]; then
-            echo "No screenshots found — skipping."
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+
+          # Snapshot PNGs added or modified in this PR (relative to base branch)
+          mapfile -t changed < <(git diff --name-only --diff-filter=AM \
+            "origin/$BASE_REF...HEAD" -- '**/__screenshots__/**/*.png')
+
+          comment_id=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.body | startswith("<!-- screenshots -->"))] | first | .id // empty')
+
+          if [ ${#changed[@]} -eq 0 ]; then
+            echo "No snapshot updates in this PR — skipping comment."
+            if [ -n "$comment_id" ]; then
+              gh api --method DELETE "repos/$OWNER/$REPO/issues/comments/$comment_id"
+              echo "Removed stale screenshots comment."
+            fi
             exit 0
           fi
 
@@ -108,7 +87,6 @@ jobs:
           asset_dir="$PR_NUMBER/$PR_SHA"
           remote="https://x-access-token:${GH_TOKEN}@github.com/$OWNER/$REPO.git"
 
-          # Clone the assets branch if it exists, otherwise start an orphan
           if git ls-remote --exit-code "$remote" "refs/heads/$ASSETS_BRANCH" >/dev/null 2>&1; then
             git clone --depth=1 --branch "$ASSETS_BRANCH" "$remote" /tmp/assets
           else
@@ -117,47 +95,26 @@ jobs:
             git -C /tmp/assets rm -rf . >/dev/null 2>&1 || true
           fi
 
-          # Filter to only new or changed screenshots vs the dev baseline
-          mkdir -p /tmp/changed
-          for f in screenshots/*.png; do
-            name=$(basename "$f")
-            baseline="/tmp/assets/dev/$name"
-            if [ ! -f "$baseline" ] || ! cmp -s "$f" "$baseline"; then
-              cp "$f" "/tmp/changed/$name"
-            fi
+          mkdir -p "/tmp/assets/$asset_dir"
+          for src in "${changed[@]}"; do
+            [ -f "$src" ] || continue
+            cp "$src" "/tmp/assets/$asset_dir/$(basename "$src")"
           done
 
-          if [ -z "$(ls /tmp/changed/*.png 2>/dev/null)" ]; then
-            echo "No new or changed screenshots — skipping comment."
-            # Remove a stale screenshots comment if one exists
-            comment_id=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
-              --jq '[.[] | select(.body | startswith("<!-- screenshots -->"))] | first | .id // empty')
-            if [ -n "$comment_id" ]; then
-              gh api --method DELETE "repos/$OWNER/$REPO/issues/comments/$comment_id"
-              echo "Removed stale screenshots comment."
-            fi
-            exit 0
-          fi
-
-          mkdir -p "/tmp/assets/$asset_dir"
-          cp /tmp/changed/*.png "/tmp/assets/$asset_dir/"
           git -C /tmp/assets add "$asset_dir"
           git -C /tmp/assets commit -m "screenshots: PR #$PR_NUMBER @ $PR_SHA"
           git -C /tmp/assets push "$remote" "$ASSETS_BRANCH"
 
           images=""
-          for f in /tmp/changed/*.png; do
-            name=$(basename "$f" .png)
+          for src in "${changed[@]}"; do
+            name=$(basename "$src" .png)
             url="https://raw.githubusercontent.com/$OWNER/$REPO/$ASSETS_BRANCH/$asset_dir/$name.png"
             images="$images\n**$name**\n![$name]($url)\n"
           done
 
           body="<!-- screenshots -->
-          ## Screenshots
+          ## Snapshot updates in this PR
           $(printf '%b' "$images")"
-
-          comment_id=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.body | startswith("<!-- screenshots -->"))] | first | .id // empty')
 
           if [ -n "$comment_id" ]; then
             gh api --method PATCH "repos/$OWNER/$REPO/issues/comments/$comment_id" \

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,7 @@ name: Playwright Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:
@@ -50,8 +50,8 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-      - name: Publish screenshot baseline (main)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Publish screenshot baseline (dev)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
@@ -76,10 +76,10 @@ jobs:
             git -C /tmp/assets rm -rf . >/dev/null 2>&1 || true
           fi
 
-          rm -rf /tmp/assets/main
-          mkdir -p /tmp/assets/main
-          cp screenshots/*.png /tmp/assets/main/
-          git -C /tmp/assets add main
+          rm -rf /tmp/assets/dev
+          mkdir -p /tmp/assets/dev
+          cp screenshots/*.png /tmp/assets/dev/
+          git -C /tmp/assets add dev
           if git -C /tmp/assets diff --cached --quiet; then
             echo "Baseline unchanged."
             exit 0
@@ -117,11 +117,11 @@ jobs:
             git -C /tmp/assets rm -rf . >/dev/null 2>&1 || true
           fi
 
-          # Filter to only new or changed screenshots vs the main baseline
+          # Filter to only new or changed screenshots vs the dev baseline
           mkdir -p /tmp/changed
           for f in screenshots/*.png; do
             name=$(basename "$f")
-            baseline="/tmp/assets/main/$name"
+            baseline="/tmp/assets/dev/$name"
             if [ ! -f "$baseline" ] || ! cmp -s "$f" "$baseline"; then
               cp "$f" "/tmp/changed/$name"
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,6 @@ tsconfig.tsbuildinfo
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
-/screenshots/
 
 # Devenv
 .devenv*

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
+  snapshotPathTemplate: "{testDir}/__screenshots__/{testFilePath}/{arg}{ext}",
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+      animations: "disabled",
+      caret: "hide",
+    },
+  },
   use: {
     baseURL: "http://localhost:8000",
     trace: "on-first-retry",

--- a/tests/e2e/example.spec.ts
+++ b/tests/e2e/example.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "@playwright/test"
 
-test("home page loads", async ({ page }) => {
+test("home page loads", async ({ page, browserName }) => {
   await page.goto("/")
   await expect(page).toHaveTitle(/The Pragmatic Papers/)
   await expect(page.locator("a[href*='/articles/']").first()).toBeVisible()
-  await page.screenshot({ path: "screenshots/home-page.png" })
+
+  test.skip(browserName !== "chromium", "visual baseline captured on chromium only")
+  await expect(page).toHaveScreenshot("home-page.png", { fullPage: true })
 })


### PR DESCRIPTION
## Summary

Previously every PR got a screenshots comment containing every image the e2e suite produced. This switches to Playwright's built-in visual regression and only comments with snapshots that were actually added or modified in the PR.

### Test changes
- `tests/e2e/example.spec.ts` uses `expect(page).toHaveScreenshot()` instead of an ad-hoc `page.screenshot({ path })`. Visual baseline runs on chromium only so we don't carry one PNG per browser/device project.
- `playwright.config.ts` adds `snapshotPathTemplate` (baselines live under `tests/e2e/__screenshots__/`) and a `maxDiffPixelRatio: 0.01` tolerance with animations/caret disabled.
- `/screenshots/` removed from `.gitignore`.

### Workflow changes (`.github/workflows/playwright.yml`)
- On PRs (excluding those targeting `main` — i.e. release PRs from `dev`), the workflow computes `git diff` of `**/__screenshots__/**/*.png` against the PR's base branch. Only those files are uploaded to `pr-screenshots/<PR>/<SHA>/` and rendered in the comment.
- If nothing changed, no comment is posted and any stale prior screenshots comment is removed.
- Added a `workflow_dispatch` with an `update_snapshots` input. When enabled, the job runs `pnpm test:e2e -- --update-snapshots --project=chromium` and pushes the regenerated baselines back to the dispatched branch — useful for seeding initial baselines or refreshing them after intentional UI changes without needing local Docker.
- `actions/checkout` now uses `fetch-depth: 0` so the diff against the base branch works.

## Seeding initial baselines

Before this can produce a green build, baselines need to exist under `tests/e2e/__screenshots__/`. Easiest path: **Actions → Playwright Tests → Run workflow**, pick this branch, check **Regenerate visual snapshots**, and run. The job will commit the generated PNGs back to the branch.

## Test plan

- [ ] Trigger the dispatch run with `update_snapshots = true` on this branch; confirm baselines get committed.
- [ ] Subsequent CI run on this PR passes and posts a screenshots comment containing the newly-added baselines (since they're "added in the PR" relative to `dev`).
- [ ] Push a no-op commit (no snapshot changes) and verify the screenshots comment is removed.
- [ ] Open a dummy PR targeting `main` and confirm no screenshots comment is posted.