### PR TITLE
test: invoke playwright binary directly so cli flags pass through

### DIFF
--- a/scripts/test-e2e.mjs
+++ b/scripts/test-e2e.mjs
@@ -32,8 +32,8 @@ try {
 
   console.warn(`${blue("●")} Starting Playwright tests...`)
   const child = spawn(
-    "pnpm",
-    ["exec", "playwright", "test", "--config=playwright.config.ts", ...process.argv.slice(2)],
+    "./node_modules/.bin/playwright",
+    ["test", "--config=playwright.config.ts", ...process.argv.slice(2)],
     { env: process.env, stdio: "inherit" },
   )
 


### PR DESCRIPTION
## Summary

Follow-up to #749. The dispatch run with `update_snapshots = true` failed with `No tests found. Make sure that arguments are regular expressions matching test files.` because the inner `pnpm exec` in `scripts/test-e2e.mjs` was parsing forwarded flags like `--update-snapshots` and `--project=chromium` as its own options before they reached Playwright.

Fix: invoke `./node_modules/.bin/playwright` directly so pnpm's arg parser stays out of the loop.

## Test plan

- [ ] Re-run **Actions → Playwright Tests → Run workflow** on `dev` with **Regenerate visual snapshots** checked.
- [ ] Verify the job commits new baselines under `tests/e2e/__screenshots__/` to `dev`.
- [ ] Verify subsequent regular CI runs on `dev` still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6K5EdYwTN9mTpRFhR9JHw)_