### PR TITLE
fix: self-heal screenshot workflow for PRs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,10 +50,13 @@ jobs:
 
       - name: Run Playwright tests
         if: ${{ !inputs.update_snapshots }}
+        id: run-tests
+        continue-on-error: true
         run: pnpm test:e2e -- --update-snapshots=missing
 
       - name: Commit new snapshot baselines
-        if: ${{ !inputs.update_snapshots }}
+        if: ${{ !cancelled() && !inputs.update_snapshots }}
+        id: commit-baselines
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -61,11 +64,21 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add tests/e2e/__screenshots__
           if git diff --cached --quiet; then
+            echo "new_baselines=false" >> "$GITHUB_OUTPUT"
             echo "No new snapshots to commit."
-            exit 0
+          else
+            git commit -m "test: add missing e2e snapshot baselines [skip ci]"
+            git push origin "HEAD:${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+            echo "new_baselines=true" >> "$GITHUB_OUTPUT"
           fi
-          git commit -m "test: add missing e2e snapshot baselines [skip ci]"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+
+      - name: Re-run chromium tests with new baselines
+        if: ${{ !inputs.update_snapshots && steps.commit-baselines.outputs.new_baselines == 'true' }}
+        run: pnpm test:e2e -- --project=chromium
+
+      - name: Fail if tests failed without new baselines
+        if: ${{ !inputs.update_snapshots && steps.commit-baselines.outputs.new_baselines != 'true' && steps.run-tests.outcome == 'failure' }}
+        run: exit 1
 
       - name: Regenerate visual snapshots
         if: ${{ inputs.update_snapshots }}
@@ -84,7 +97,7 @@ jobs:
             exit 0
           fi
           git commit -m "test: update e2e visual snapshots"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "HEAD:${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
 
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` on the test step so the workflow can inspect results before deciding to fail
- Use `GITHUB_HEAD_REF` (PR branch name) when pushing commits from within a pull request, falling back to `GITHUB_REF_NAME` — fixes the push that was previously broken on PR workflows
- Output `new_baselines` flag from the commit step; re-run chromium tests when new baselines were just committed, then fail only if tests failed *without* any new baselines being the cause

## Test plan

- [ ] Open a PR that introduces a new snapshot — workflow should auto-commit the baseline and pass
- [ ] Open a PR with a failing test (not baseline-related) — workflow should still fail correctly
- [ ] Trigger `update_snapshots` manually — push to the PR branch should succeed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)