### PR TITLE
Add fingerprinting to screenshot comments to skip redundant uploads

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -123,8 +123,13 @@ jobs:
           mapfile -t changed < <(git diff --name-only --diff-filter=AM \
             "origin/$BASE_REF...HEAD" -- '**/__screenshots__/**/*.png')
 
-          comment_id=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | select(.body | startswith("<!-- screenshots -->"))] | first | .id // empty')
+          existing=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.body | startswith("<!-- screenshots"))] | first | {id: .id, body: .body} // empty')
+          comment_id=$(printf '%s' "$existing" | jq -r '.id // empty')
+          existing_fingerprint=$(printf '%s' "$existing" \
+            | jq -r '.body // empty' \
+            | sed -n 's/^<!-- screenshots:\([0-9a-f]*\) -->.*/\1/p' \
+            | head -n1)
 
           if [ ${#changed[@]} -eq 0 ]; then
             echo "No snapshot updates in this PR — skipping comment."
@@ -132,6 +137,16 @@ jobs:
               gh api --method DELETE "repos/$OWNER/$REPO/issues/comments/$comment_id"
               echo "Removed stale screenshots comment."
             fi
+            exit 0
+          fi
+
+          fingerprint=$(printf '%s\n' "${changed[@]}" \
+            | sort \
+            | xargs -I{} sha256sum {} \
+            | sha256sum | awk '{print $1}')
+
+          if [ -n "$existing_fingerprint" ] && [ "$existing_fingerprint" = "$fingerprint" ]; then
+            echo "Screenshots unchanged — skipping upload."
             exit 0
           fi
 
@@ -166,7 +181,7 @@ jobs:
             images="$images\n**$name**\n![$name]($url)\n"
           done
 
-          body="<!-- screenshots -->
+          body="<!-- screenshots:$fingerprint -->
           ## Snapshot updates in this PR
           $(printf '%b' "$images")"
 


### PR DESCRIPTION
## Context

This PR improves the screenshot upload workflow by adding fingerprint-based deduplication. Previously, the workflow would attempt to upload screenshots on every PR update, even if the actual screenshot files hadn't changed. This caused unnecessary uploads and comment updates.

The changes:
1. Extract and store a fingerprint (SHA256 hash) of the changed screenshot files in the comment body
2. On subsequent runs, compute the fingerprint of the current changed files and compare it to the stored fingerprint
3. Skip the upload and comment update if the fingerprints match, indicating no actual changes to the screenshots
4. Update the comment marker format from `<!-- screenshots -->` to `<!-- screenshots:FINGERPRINT -->` to embed the fingerprint

This reduces unnecessary artifact uploads and keeps the PR cleaner by avoiding redundant comment updates when screenshots haven't actually changed.

## Test Plan

The existing CI workflow will validate this change. The fingerprinting logic can be verified by:
1. Creating a PR with screenshot changes - should upload and create a comment with a fingerprint
2. Pushing another commit without modifying screenshots - should skip upload and exit early
3. Modifying screenshots again - should detect the fingerprint change and upload the new screenshots

https://claude.ai/code/session_01C9YP8NuWjxdHfTiEhvUJVu