### PR TITLE
Cut E2E test time from ~7 min to ~3 min

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,13 +50,10 @@ jobs:
 
       - name: Run Playwright tests
         if: ${{ !inputs.update_snapshots }}
-        id: run-tests
-        continue-on-error: true
         run: pnpm test:e2e -- --update-snapshots=missing
 
       - name: Commit new snapshot baselines
         if: ${{ !cancelled() && !inputs.update_snapshots }}
-        id: commit-baselines
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -64,21 +61,11 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add tests/e2e/__screenshots__
           if git diff --cached --quiet; then
-            echo "new_baselines=false" >> "$GITHUB_OUTPUT"
             echo "No new snapshots to commit."
           else
             git commit -m "test: add missing e2e snapshot baselines [skip ci]"
             git push origin "HEAD:${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
-            echo "new_baselines=true" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Re-run chromium tests with new baselines
-        if: ${{ !inputs.update_snapshots && steps.commit-baselines.outputs.new_baselines == 'true' }}
-        run: pnpm test:e2e -- --project=chromium
-
-      - name: Fail if tests failed without new baselines
-        if: ${{ !inputs.update_snapshots && steps.commit-baselines.outputs.new_baselines != 'true' && steps.run-tests.outcome == 'failure' }}
-        run: exit 1
 
       - name: Regenerate visual snapshots
         if: ${{ inputs.update_snapshots }}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:coverage": "vitest run --coverage",
     "coverage:report": "tsx scripts/coverage-report.ts",
     "test:e2e": "node scripts/test-e2e.mjs",
+    "test:e2e:all": "E2E_ALL_BROWSERS=true node scripts/test-e2e.mjs",
     "release": "node scripts/release.mjs"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,46 +3,6 @@ import dotenv from "dotenv"
 
 dotenv.config()
 
-const allBrowserProjects = [
-  {
-    name: "chromium",
-    use: { ...devices["Desktop Chrome"] },
-  },
-  {
-    name: "firefox",
-    use: { ...devices["Desktop Firefox"] },
-  },
-  {
-    name: "webkit",
-    use: { ...devices["Desktop Safari"] },
-  },
-  /* Mobile viewports. */
-  {
-    name: "Mobile Chrome",
-    use: { ...devices["Pixel 5"] },
-  },
-  {
-    name: "Mobile Safari",
-    use: { ...devices["iPhone 12"] },
-  },
-
-  /* Tablet viewport. */
-  {
-    name: "Tablet",
-    use: { ...devices["iPad (gen 7)"] },
-  },
-
-  /* Test against branded browsers. */
-  // {
-  //   name: 'Microsoft Edge',
-  //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-  // },
-  // {
-  //   name: 'Google Chrome',
-  //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-  // },
-]
-
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
@@ -62,7 +22,49 @@ export default defineConfig({
     baseURL: "http://localhost:8000",
     trace: "on-first-retry",
   },
-  projects: process.env.E2E_ALL_BROWSERS ? allBrowserProjects : [allBrowserProjects[0]],
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    ...(process.env.E2E_ALL_BROWSERS
+      ? [
+          {
+            name: "firefox",
+            use: { ...devices["Desktop Firefox"] },
+          },
+          {
+            name: "webkit",
+            use: { ...devices["Desktop Safari"] },
+          },
+          /* Mobile viewports. */
+          {
+            name: "Mobile Chrome",
+            use: { ...devices["Pixel 5"] },
+          },
+          {
+            name: "Mobile Safari",
+            use: { ...devices["iPhone 12"] },
+          },
+
+          /* Tablet viewport. */
+          {
+            name: "Tablet",
+            use: { ...devices["iPad (gen 7)"] },
+          },
+
+          /* Test against branded browsers. */
+          // {
+          //   name: 'Microsoft Edge',
+          //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+          // },
+          // {
+          //   name: 'Google Chrome',
+          //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+          // },
+        ]
+      : []),
+  ],
   webServer: {
     command: process.env.E2E_MANAGED_SERVER
       ? "echo 'server managed externally'"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,46 @@ import dotenv from "dotenv"
 
 dotenv.config()
 
+const allBrowserProjects = [
+  {
+    name: "chromium",
+    use: { ...devices["Desktop Chrome"] },
+  },
+  {
+    name: "firefox",
+    use: { ...devices["Desktop Firefox"] },
+  },
+  {
+    name: "webkit",
+    use: { ...devices["Desktop Safari"] },
+  },
+  /* Mobile viewports. */
+  {
+    name: "Mobile Chrome",
+    use: { ...devices["Pixel 5"] },
+  },
+  {
+    name: "Mobile Safari",
+    use: { ...devices["iPhone 12"] },
+  },
+
+  /* Tablet viewport. */
+  {
+    name: "Tablet",
+    use: { ...devices["iPad (gen 7)"] },
+  },
+
+  /* Test against branded browsers. */
+  // {
+  //   name: 'Microsoft Edge',
+  //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+  // },
+  // {
+  //   name: 'Google Chrome',
+  //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+  // },
+]
+
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
@@ -22,49 +62,13 @@ export default defineConfig({
     baseURL: "http://localhost:8000",
     trace: "on-first-retry",
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
-    /* Mobile viewports. */
-    {
-      name: "Mobile Chrome",
-      use: { ...devices["Pixel 5"] },
-    },
-    {
-      name: "Mobile Safari",
-      use: { ...devices["iPhone 12"] },
-    },
-
-    /* Tablet viewport. */
-    {
-      name: "Tablet",
-      use: { ...devices["iPad (gen 7)"] },
-    },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
-  ],
+  projects: process.env.E2E_ALL_BROWSERS ? allBrowserProjects : [allBrowserProjects[0]],
   webServer: {
-    command: "pnpm dev:next",
+    command: process.env.E2E_MANAGED_SERVER
+      ? "echo 'server managed externally'"
+      : "pnpm dev:next",
     url: process.env.NEXT_PUBLIC_SERVER_URL || "http://localhost:8000",
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !!process.env.E2E_MANAGED_SERVER || !process.env.CI,
     timeout: 120_000,
   },
 })

--- a/scripts/test-e2e.mjs
+++ b/scripts/test-e2e.mjs
@@ -1,6 +1,20 @@
 import { PostgreSqlContainer } from "@testcontainers/postgresql"
 import { execSync, spawn } from "node:child_process"
-import { blue, green, red } from "./ansi.mjs"
+import net from "node:net"
+import { blue, green, red, yellow } from "./ansi.mjs"
+
+function isPortInUse(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ port, host: "127.0.0.1" })
+    socket.once("connect", () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once("error", () => {
+      resolve(false)
+    })
+  })
+}
 
 console.warn(`${blue("●")} Starting Postgres container...`)
 const container = await new PostgreSqlContainer("postgres:15-alpine")
@@ -20,8 +34,16 @@ console.warn(`${green("✔")} Test database started at ${uri}`)
 
 let server = null
 try {
-  console.warn(`${blue("●")} Starting Next.js dev server...`)
-  server = spawn("pnpm", ["dev:next"], { env: process.env, stdio: "inherit" })
+  const port = Number(process.env.PORT)
+  if (await isPortInUse(port)) {
+    console.warn(
+      `${yellow("⚠")} Port ${port} is already in use — reusing existing server. ` +
+        `Tests will fail unless it's connected to the test container at ${uri}.`,
+    )
+  } else {
+    console.warn(`${blue("●")} Starting Next.js dev server...`)
+    server = spawn("pnpm", ["dev:next"], { env: process.env, stdio: "inherit" })
+  }
 
   console.warn(`${blue("●")} Running database migrations...`)
   execSync("pnpm payload migrate", {

--- a/scripts/test-e2e.mjs
+++ b/scripts/test-e2e.mjs
@@ -1,7 +1,7 @@
 import { PostgreSqlContainer } from "@testcontainers/postgresql"
 import { execSync, spawn } from "node:child_process"
 import net from "node:net"
-import { blue, green, red, yellow } from "./ansi.mjs"
+import { blue, green, red } from "./ansi.mjs"
 
 function isPortInUse(port) {
   return new Promise((resolve) => {
@@ -32,18 +32,20 @@ process.env.E2E_MANAGED_SERVER = "true"
 
 console.warn(`${green("✔")} Test database started at ${uri}`)
 
+const port = Number(process.env.PORT)
+if (await isPortInUse(port)) {
+  console.error(
+    `${red("✖")} Port ${port} is already in use. ` +
+      `Stop the process bound to it (e.g. \`lsof -ti:${port} | xargs kill\`) before running E2E tests.`,
+  )
+  await container.stop()
+  process.exit(1)
+}
+
 let server = null
 try {
-  const port = Number(process.env.PORT)
-  if (await isPortInUse(port)) {
-    console.warn(
-      `${yellow("⚠")} Port ${port} is already in use — reusing existing server. ` +
-        `Tests will fail unless it's connected to the test container at ${uri}.`,
-    )
-  } else {
-    console.warn(`${blue("●")} Starting Next.js dev server...`)
-    server = spawn("pnpm", ["dev:next"], { env: process.env, stdio: "inherit" })
-  }
+  console.warn(`${blue("●")} Starting Next.js dev server...`)
+  server = spawn("pnpm", ["dev:next"], { env: process.env, stdio: "inherit" })
 
   console.warn(`${blue("●")} Running database migrations...`)
   execSync("pnpm payload migrate", {

--- a/scripts/test-e2e.mjs
+++ b/scripts/test-e2e.mjs
@@ -14,10 +14,15 @@ process.env.USE_LOCAL_STORAGE ??= "true"
 process.env.PORT ??= "8000"
 process.env.NEXT_PUBLIC_SERVER_URL ??= `http://localhost:${process.env.PORT}`
 process.env.PAYLOAD_CONFIG_PATH ??= "src/payload.config.ts"
+process.env.E2E_MANAGED_SERVER = "true"
 
 console.warn(`${green("✔")} Test database started at ${uri}`)
 
+let server = null
 try {
+  console.warn(`${blue("●")} Starting Next.js dev server...`)
+  server = spawn("pnpm", ["dev:next"], { env: process.env, stdio: "inherit" })
+
   console.warn(`${blue("●")} Running database migrations...`)
   execSync("pnpm payload migrate", {
     env: process.env,
@@ -43,6 +48,7 @@ try {
   console.error(`${red("✖")} Error during E2E test setup: ${error.message}`)
   process.exitCode = 1
 } finally {
+  server?.kill()
   console.warn(`${blue("●")} Stopping Postgres container...`)
   await container.stop()
 }


### PR DESCRIPTION
## Context

E2E tests were taking ~7 minutes. Three things were adding up:

1. **6 browser projects running the same single test sequentially.** The only test file (`example.spec.ts`) `.skip()`s its screenshot assertion on every browser except Chromium, so 5 of 6 runs were just re-checking the title and link visibility — pure overhead.
2. **Server startup was fully serialized after migrations + seeding.** `test-e2e.mjs` waited for migrate (~60s) and seed (~20s), *then* Playwright spawned `pnpm dev:next` and waited another ~90s for it to come up.
3. **CI ran the suite twice on PRs that produced new snapshot baselines** — once with `--update-snapshots=missing` (continue-on-error), then again to "verify" after committing the baselines. The re-run wasn't actually verifying anything meaningful.

## Changes

### 1. Default to Chromium only (`playwright.config.ts`)

The `projects` array now contains only Chromium by default. Setting `E2E_ALL_BROWSERS=true` spreads in Firefox, WebKit, and the mobile/tablet viewports. A new `test:e2e:all` script wires this up for opt-in cross-browser runs.

### 2. Overlap server startup with migrations + seeding (`scripts/test-e2e.mjs`)

The dev server is spawned as soon as the testcontainer is up (it has `DATABASE_URI` immediately), then migrations and seeding run in the foreground. By the time seeding finishes, the server has been booting for ~80s of its ~90s startup, so Playwright begins testing almost immediately rather than waiting another 90s.

`E2E_MANAGED_SERVER=true` tells the Playwright config to:
- Replace `webServer.command` with a no-op `echo` (Playwright still polls `url` for readiness — no custom poller needed)
- Set `reuseExistingServer: true` so it attaches to the server we already started

### 3. Fail fast on port conflict

If port 8000 is already in use when `test-e2e.mjs` starts, the script tears down the container and exits with an actionable error (`lsof -ti:8000 | xargs kill`). The testcontainer URI is unique per run, so any pre-existing server is guaranteed to be pointed at the wrong DB — reusing it would just produce confusing downstream failures.

### 4. Remove the CI double-run (`.github/workflows/playwright.yml`)

The "re-run chromium tests with new baselines" step is gone, along with the `continue-on-error: true` and the conditional fail step. `--update-snapshots=missing` already passes when a baseline is created, and the auto-commit step still runs on test failures via `if: !cancelled()`, so genuine visual regressions still fail the workflow while new baselines still get committed.

## Expected speedup

| Phase                          | Before                | After                |
| ------------------------------ | --------------------- | -------------------- |
| Container + migrate + seed     | ~100s                 | ~100s (unchanged)    |
| Server startup (overlapped)    | +90s sequential       | ~10s remaining       |
| Test execution                 | 6 browsers × ~20s     | 1 browser × ~20s     |
| CI re-run after baseline commit | full extra run        | eliminated           |
| **Total**                      | **~7 min**            | **~3 min**           |

## Test plan

- [x] `pnpm test:e2e` finishes in ~3 min on Chromium only
- [x] `pnpm test:e2e:all` runs the full 6-browser matrix
- [x] CI workflow runs once, commits new baselines if generated, no second run
- [x] Running `pnpm test:e2e` while `pnpm dev` is already up exits immediately with the port-conflict error

https://claude.ai/code/session_01TiUmxzxvJRvrk8jW96x6X4