### PR TITLE
Refactor E2E test server startup to use Next.js CLI directly

### DIFF
--- a/scripts/test-e2e.mjs
+++ b/scripts/test-e2e.mjs
@@ -45,7 +45,11 @@ if (await isPortInUse(port)) {
 let server = null
 try {
   console.warn(`${blue("●")} Starting Next.js dev server...`)
-  server = spawn("pnpm", ["dev:next"], { env: process.env, stdio: "inherit" })
+  server = spawn(
+    "./node_modules/.bin/next",
+    ["dev", "-p", String(process.env.PORT), "--turbopack"],
+    { env: { ...process.env, NODE_OPTIONS: "--no-deprecation" }, stdio: "inherit" },
+  )
 
   console.warn(`${blue("●")} Running database migrations...`)
   execSync("pnpm payload migrate", {
@@ -72,7 +76,10 @@ try {
   console.error(`${red("✖")} Error during E2E test setup: ${error.message}`)
   process.exitCode = 1
 } finally {
-  server?.kill()
+  if (server) {
+    server.kill("SIGTERM")
+    await new Promise((resolve) => server.once("exit", resolve))
+  }
   console.warn(`${blue("●")} Stopping Postgres container...`)
   await container.stop()
 }


### PR DESCRIPTION
## Context

This PR refactors the E2E test setup script to invoke the Next.js dev server directly via the CLI instead of through the `pnpm dev:next` script. This change provides more explicit control over server startup parameters and improves server shutdown handling.

**Key changes:**
- Replace `pnpm dev:next` with direct invocation of `./node_modules/.bin/next dev` with explicit flags (`-p` for port, `--turbopack`)
- Add `NODE_OPTIONS: "--no-deprecation"` to suppress deprecation warnings during tests
- Improve server shutdown by explicitly sending `SIGTERM` and waiting for the process to exit before proceeding

These changes ensure more reliable and predictable E2E test execution with better control over Next.js dev server configuration.

## Test Plan

Run the E2E test suite to verify:
1. The Next.js dev server starts successfully on the specified port with Turbopack enabled
2. Database migrations execute without errors
3. E2E tests run and complete successfully
4. The server shuts down cleanly without hanging processes

Verify that `pnpm test:e2e` completes successfully and all tests pass.

https://claude.ai/code/session_01TiUmxzxvJRvrk8jW96x6X4