### PR TITLE
Replace Testcontainers with GitHub Actions service containers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,21 @@ jobs:
       PAYLOAD_SECRET: ci-payload-secret
       USE_LOCAL_STORAGE: "true"
 
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pragmatic-papers
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -98,6 +113,22 @@ jobs:
     env:
       PAYLOAD_SECRET: ci-integration-secret
       USE_LOCAL_STORAGE: "true"
+      DATABASE_URI: postgres://postgres:postgres@localhost:5432/pp_template
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pp_template
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,6 +25,22 @@ jobs:
       PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
       NEXT_PUBLIC_SERVER_URL: http://localhost:8000
       USE_LOCAL_STORAGE: "true"
+      DATABASE_URI: postgres://postgres:postgres@localhost:5432/pragmatic-papers-e2e
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pragmatic-papers-e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v6

--- a/scripts/check-pending-migrations.mjs
+++ b/scripts/check-pending-migrations.mjs
@@ -2,17 +2,21 @@ import { PostgreSqlContainer } from "@testcontainers/postgresql"
 import { execSync } from "node:child_process"
 import { blue, green, red } from "./ansi.mjs"
 
-console.warn(`${blue("●")} Starting Postgres container for migration check...`)
-const container = await new PostgreSqlContainer("postgres:15-alpine")
-  .withDatabase("pragmatic-papers-test")
-  .start()
-
-const uri = container.getConnectionUri()
-process.env.DATABASE_URI = uri
 process.env.PAYLOAD_SECRET ??= "test-secret"
 process.env.USE_LOCAL_STORAGE ??= "true"
 
-console.warn(`${green("✔")} Test database started at ${uri}`)
+let container = null
+
+if (process.env.DATABASE_URI) {
+  console.warn(`${green("✔")} Using existing DATABASE_URI — skipping container startup.`)
+} else {
+  console.warn(`${blue("●")} Starting Postgres container for migration check...`)
+  container = await new PostgreSqlContainer("postgres:15-alpine")
+    .withDatabase("pragmatic-papers-test")
+    .start()
+  process.env.DATABASE_URI = container.getConnectionUri()
+  console.warn(`${green("✔")} Test database started at ${process.env.DATABASE_URI}`)
+}
 
 try {
   console.warn(`${blue("●")} Running existing migrations...`)
@@ -45,6 +49,8 @@ try {
   if (error.stderr) console.error(error.stderr)
   process.exit(1)
 } finally {
-  console.warn(`${blue("●")} Stopping Postgres container...`)
-  await container.stop()
+  if (container) {
+    console.warn(`${blue("●")} Stopping Postgres container...`)
+    await container.stop()
+  }
 }

--- a/scripts/test-e2e.mjs
+++ b/scripts/test-e2e.mjs
@@ -16,21 +16,25 @@ function isPortInUse(port) {
   })
 }
 
-console.warn(`${blue("●")} Starting Postgres container...`)
-const container = await new PostgreSqlContainer("postgres:15-alpine")
-  .withDatabase("pragmatic-papers-test")
-  .start()
-
-const uri = container.getConnectionUri()
-process.env.DATABASE_URI = uri
 process.env.PAYLOAD_SECRET ??= "test-secret-for-e2e-tests"
+
+let container = null
+
+if (process.env.DATABASE_URI) {
+  console.warn(`${green("✔")} Using existing DATABASE_URI — skipping container startup.`)
+} else {
+  console.warn(`${blue("●")} Starting Postgres container...`)
+  container = await new PostgreSqlContainer("postgres:15-alpine")
+    .withDatabase("pragmatic-papers-test")
+    .start()
+  process.env.DATABASE_URI = container.getConnectionUri()
+  console.warn(`${green("✔")} Test database started at ${process.env.DATABASE_URI}`)
+}
 process.env.USE_LOCAL_STORAGE ??= "true"
 process.env.PORT ??= "8000"
 process.env.NEXT_PUBLIC_SERVER_URL ??= `http://localhost:${process.env.PORT}`
 process.env.PAYLOAD_CONFIG_PATH ??= "src/payload.config.ts"
 process.env.E2E_MANAGED_SERVER = "true"
-
-console.warn(`${green("✔")} Test database started at ${uri}`)
 
 const port = Number(process.env.PORT)
 if (await isPortInUse(port)) {
@@ -80,6 +84,8 @@ try {
     server.kill("SIGTERM")
     await new Promise((resolve) => server.once("exit", resolve))
   }
-  console.warn(`${blue("●")} Stopping Postgres container...`)
-  await container.stop()
+  if (container) {
+    console.warn(`${blue("●")} Stopping Postgres container...`)
+    await container.stop()
+  }
 }

--- a/tests/setup/integration-global-setup.ts
+++ b/tests/setup/integration-global-setup.ts
@@ -4,17 +4,24 @@ import { execSync } from "node:child_process"
 const TEMPLATE_DB = "pp_template"
 
 export async function setup(): Promise<() => Promise<void>> {
-  const container = await new PostgreSqlContainer("postgres:15-alpine")
-    .withDatabase(TEMPLATE_DB)
-    .start()
-
-  const uri = container.getConnectionUri()
-  process.env.DATABASE_URI = uri
   process.env.PAYLOAD_SECRET ??= "test-secret-for-integration-tests"
   process.env.USE_LOCAL_STORAGE ??= "true"
   process.env.NEXT_PUBLIC_SERVER_URL ??= "http://localhost:8000"
 
-  console.warn(`Integration test database started at ${uri}`)
+  let container = null
+  let uri: string
+
+  if (process.env.DATABASE_URI) {
+    uri = process.env.DATABASE_URI
+    console.warn(`Using existing DATABASE_URI — skipping container startup.`)
+  } else {
+    container = await new PostgreSqlContainer("postgres:15-alpine")
+      .withDatabase(TEMPLATE_DB)
+      .start()
+    uri = container.getConnectionUri()
+    process.env.DATABASE_URI = uri
+    console.warn(`Integration test database started at ${uri}`)
+  }
 
   try {
     console.warn("Running database migrations on template database...")
@@ -24,7 +31,7 @@ export async function setup(): Promise<() => Promise<void>> {
     })
   } catch (error) {
     console.error("Error during integration test migration:", error)
-    await container.stop()
+    if (container) await container.stop()
     throw error
   }
 
@@ -38,6 +45,6 @@ export async function setup(): Promise<() => Promise<void>> {
   process.env.PG_TEMPLATE_DB = TEMPLATE_DB
 
   return async (): Promise<void> => {
-    await container.stop()
+    if (container) await container.stop()
   }
 }


### PR DESCRIPTION
## Summary

- Adds a native GitHub Actions `services.postgres` block to all three CI jobs (lint/unit, integration, E2E/Playwright) so Postgres is provided by the runner instead of started via Testcontainers
- Updates `scripts/check-pending-migrations.mjs`, `scripts/test-e2e.mjs`, and `tests/setup/integration-global-setup.ts` to skip Testcontainer startup when `DATABASE_URI` is already set, keeping local dev working without changes

## Test plan

- [ ] CI passes (lint, integration, and E2E jobs all connect to the service container DB)
- [ ] Local `pnpm test:integration` and `pnpm test:e2e` still work (Testcontainers path still exercised when no `DATABASE_URI` is set)
- [ ] Screenshots workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)