### PR TITLE
Add Claude AI code review, triggered by 'ready for review' label

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,48 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+    branches: [dev]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude review
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_CODE_REVIEW }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+            - Adherence to the project conventions documented in AGENTS.md (Payload CMS collection/block/field patterns, access control, test coverage expectations)
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   review:
     name: Claude review
-    if: github.event.label.name == 'ai-review'
+    if: github.event.label.name == 'ready for review'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    types: [labeled]
     branches: [dev]
 
 concurrency:
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   review:
     name: Claude review
-    if: github.event.pull_request.draft == false
+    if: github.event.label.name == 'ai-review'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,22 +27,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_CODE_REVIEW }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
-            - Adherence to the project conventions documented in AGENTS.md (Payload CMS collection/block/field patterns, access control, test coverage expectations)
-
-            Note: The PR branch is already checked out in the current working directory.
-
-            Use `gh pr comment` for top-level feedback.
-            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
-            Only post GitHub comments - don't submit review text as messages.
-
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml`: runs `anthropics/claude-code-action` against PRs targeting `dev`
- Review only fires when the existing `ready for review` label is applied to the PR (not automatically on PR creation/sync), so it can be invoked on demand
- Uses the official `code-review:code-review` skill (`--comment` mode) to post top-level and inline PR feedback, authenticated via the existing `ANTHROPIC_API_KEY_CODE_REVIEW` secret

## Test plan
- [ ] Open or use an existing PR into `dev`
- [ ] Apply the `ready for review` label
- [ ] Confirm the `Claude Code Review` workflow run starts and posts a review comment on the PR
- [ ] Confirm removing/re-adding the label re-triggers the review


---
_Generated by [Claude Code](https://claude.ai/code/session_01LAaf4k3xEV9gcPDtpCKaQ7)_