### PR TITLE
Enable code-review plugin for Claude code review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_CODE_REVIEW }}
+          plugins: code-review@claude-code-plugins
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Context

This PR enables the `code-review` plugin for the Claude code review GitHub Action. The plugin provides enhanced code review capabilities and is required for the code review workflow to function properly.

The change adds the `plugins: code-review@claude-code-plugins` configuration to the Claude code action step, which loads the code-review plugin that powers the `/code-review` command used in the workflow.

## Test Plan

The code review workflow will automatically test this change on the next pull request. The workflow will execute with the plugin enabled and should successfully generate code review comments using the enhanced code-review plugin capabilities.

https://claude.ai/code/session_01LAaf4k3xEV9gcPDtpCKaQ7