### PR TITLE
Improve Claude code review workflow configuration

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_CODE_REVIEW }}
+          plugin_marketplaces: https://github.com/anthropics/claude-code.git
           plugins: code-review@claude-code-plugins
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           claude_args: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,6 +14,7 @@ jobs:
     name: Claude review
     if: github.event.label.name == 'ready for review'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -22,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - uses: anthropics/claude-code-action@v1
         with:
@@ -30,5 +31,3 @@ jobs:
           plugin_marketplaces: https://github.com/anthropics/claude-code.git
           plugins: code-review@claude-code-plugins
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Context

This PR updates the Claude code review GitHub Actions workflow to improve its reliability and functionality:

1. **Add job timeout**: Sets a 20-minute timeout to prevent workflows from hanging indefinitely
2. **Fetch full git history**: Changes `fetch-depth` from 1 to 0 to ensure the code review action has access to the complete repository history, which may be needed for proper context analysis
3. **Update plugin configuration**: Migrates to the new plugin marketplace approach by explicitly specifying the `plugin_marketplaces` input instead of relying on deprecated `claude_args` for tool allowlisting
4. **Simplify tool configuration**: Removes the manual `claude_args` configuration in favor of the cleaner plugin marketplace approach

These changes align with the latest Claude code action API and improve the robustness of the review process.

## Test Plan

The workflow will be tested automatically on the next pull request labeled with "ready for review". Verify that:
- The code review job completes within the 20-minute timeout
- The review comments are posted successfully to the PR
- The code review action can access necessary git history for analysis

https://claude.ai/code/session_01LAaf4k3xEV9gcPDtpCKaQ7