### PR TITLE
Name the steps in the Claude code review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,11 +21,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      - name: Run Claude code review
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_CODE_REVIEW }}
           plugin_marketplaces: https://github.com/anthropics/claude-code.git


### PR DESCRIPTION
Adds explicit `name:` to both steps in the Claude code review workflow so they read clearly in the Actions UI:

- `Checkout repository`
- `Run Claude code review`

No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAaf4k3xEV9gcPDtpCKaQ7)_