### PR TITLE
Cache Next.js build cache in CI workflows

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .next/cache
-          key: nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          key: nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**/*.[jt]s', 'src/**/*.[jt]sx', '*.[jt]s', '*.[jt]sx') }}
           restore-keys: |
             nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,6 +71,17 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
+      # Restores Next.js incremental compilation cache so `next build` inside
+      # the E2E run only recompiles what changed since the last run on this
+      # branch (or dev).
+      - name: Cache Next.js build cache
+        uses: actions/cache@v5
+        with:
+          path: .next/cache
+          key: nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .next/cache
-          key: nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          key: nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**/*.[jt]s', 'src/**/*.[jt]sx', '*.[jt]s', '*.[jt]sx') }}
           restore-keys: |
             nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -63,6 +63,14 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
+      - name: Cache Next.js build cache
+        uses: actions/cache@v5
+        with:
+          path: .next/cache
+          key: nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+
       - name: Regenerate every snapshot baseline
         run: pnpm test:e2e -- --update-snapshots=all --project=chromium
 


### PR DESCRIPTION
## Context

This PR adds caching for the Next.js incremental compilation cache (`.next/cache`) in both the Playwright E2E tests and snapshot update workflows. This optimization allows `next build` to only recompile what changed since the last run on the branch, reducing CI build times.

The cache key is based on the dependency lockfile hash and the current commit SHA, with a fallback to restore caches from the same dependency state on any commit. This ensures cache hits when dependencies haven't changed while maintaining correctness across dependency updates.

## Test Plan

The CI workflows will automatically use the new cache during their next runs. Build times for `next build` should be noticeably faster on subsequent runs within the same branch, particularly when only a small subset of files have changed.

https://claude.ai/code/session_01PLrpFW4suyQCUBh9FUfFAi