### PR TITLE
Allow triggering snapshot baseline updates via PR label

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -5,8 +5,17 @@ name: Update snapshot baselines
 # ever meant to run on workflow_dispatch would otherwise show up as a
 # permanently "skipped" check on every regular PR/push run of Playwright
 # Tests.
+#
+# Two ways to fire it:
+#   - workflow_dispatch (Actions tab, or `gh workflow run update-snapshots.yml
+#     --ref <branch>`)
+#   - adding the "needs screenshots" label to a PR. The label is removed
+#     automatically once this job finishes so it can be re-added later to
+#     retrigger.
 on:
   workflow_dispatch:
+  pull_request:
+    types: [labeled]
 
 env:
   PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
@@ -18,6 +27,7 @@ env:
 jobs:
   update-snapshots:
     name: Update snapshot baselines
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'needs screenshots' }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
 
@@ -45,6 +55,27 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
+      # pull_request's $GITHUB_REF_NAME is "<number>/merge", not the branch —
+      # resolve the real branch/PR/base once so every later step can rely on
+      # it regardless of which trigger fired.
+      - name: Resolve PR context
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "branch=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "base=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+            pr=$(gh pr list --repo "${{ github.repository }}" --head "$GITHUB_REF_NAME" \
+              --state open --json number,baseRefName --jq 'first | @json' || true)
+            echo "number=$(printf '%s' "$pr" | jq -r '.number // empty')" >> "$GITHUB_OUTPUT"
+            echo "base=$(printf '%s' "$pr" | jq -r '.baseRefName // empty')" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Node.js environment
         uses: ./.github/actions/setup-project
@@ -88,7 +119,7 @@ jobs:
             exit 0
           fi
           git commit -m "test: update e2e snapshot baselines"
-          git push origin "HEAD:$GITHUB_REF_NAME"
+          git push origin "HEAD:${{ steps.pr.outputs.branch }}"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
       # Pushes made with GITHUB_TOKEN don't trigger workflows, so the snapshot
@@ -115,22 +146,14 @@ jobs:
           done
 
       - name: Post snapshot updates comment
-        if: ${{ steps.commit.outputs.committed == 'true' }}
+        if: ${{ steps.commit.outputs.committed == 'true' && steps.pr.outputs.number != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_REF: ${{ steps.pr.outputs.base }}
         run: |
-          pr=$(gh pr list --repo "$OWNER/$REPO" --head "$GITHUB_REF_NAME" \
-            --state open --json number,baseRefName \
-            --jq 'first | @json' || true)
-          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
-            echo "No open PR for $GITHUB_REF_NAME — skipping comment."
-            exit 0
-          fi
-          PR_NUMBER=$(printf '%s' "$pr" | jq -r .number)
-          BASE_REF=$(printf '%s' "$pr" | jq -r .baseRefName)
-          export PR_NUMBER
           export ASSET_DIR="$PR_NUMBER/$(git rev-parse HEAD)"
           git fetch --no-tags --depth=1 origin "$BASE_REF"
           git diff --name-only --diff-filter=AM \
@@ -138,21 +161,25 @@ jobs:
             | pnpm exec tsx scripts/pr-screenshot-comment.ts
 
       - name: Delete stale visual regression comment
-        if: ${{ steps.commit.outputs.committed == 'true' }}
+        if: ${{ steps.commit.outputs.committed == 'true' && steps.pr.outputs.number != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           MARKER: visual-regressions
           ASSET_DIR: unused
           DELETE_WHEN_EMPTY: "true"
+        run: pnpm exec tsx scripts/pr-screenshot-comment.ts </dev/null
+
+      - name: Remove trigger label
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pr=$(gh pr list --repo "$OWNER/$REPO" --head "$GITHUB_REF_NAME" \
-            --state open --json number --jq 'first | .number' || true)
-          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
-            exit 0
-          fi
-          PR_NUMBER="$pr" pnpm exec tsx scripts/pr-screenshot-comment.ts </dev/null
+          gh api --method DELETE \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/needs%20screenshots" \
+            || true
 
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -48,6 +48,10 @@ gh workflow run update-snapshots.yml --ref <your-branch>
 (or Actions → Update snapshot baselines → Run workflow, if you'd rather use the
 browser). No inputs needed — it always regenerates all baselines.
 
+On a PR, you can trigger the same thing by adding the **`needs screenshots`**
+label — no CLI or Actions tab needed. The label is removed automatically once
+the run finishes, so re-adding it later triggers another regeneration.
+
 ## Keeping screenshots stable
 
 - Use `waitForStableRender(page)` (fonts + paint settle) before every


### PR DESCRIPTION
## Context

Follow-up to #817 (the visual-regression CI rework). Accepting an intentional visual change currently requires either the Actions UI or a `gh workflow run` command. This adds a lower-friction alternative: adding the **`needs screenshots`** label to a PR fires the same "Update snapshot baselines" job. The label is removed automatically once the job finishes, so re-adding it later triggers another regeneration.

Also fixes a latent bug this surfaced: `pull_request`'s `$GITHUB_REF_NAME` is the merge ref (`<number>/merge`), not the branch name, so the existing steps (which relied on it for pushing the snapshot commit and for the `gh pr list` lookup) would have broken silently under the new label trigger. The PR number/branch/base are now resolved once up front from the event payload when triggered by a label, falling back to the existing `gh pr list` lookup for `workflow_dispatch`.

**Note:** the `needs screenshots` label needs to exist in the repo (Settings → Labels) before it can be added to a PR — it isn't created automatically.

## Test Plan

- Validated the underlying "Update snapshot baselines" workflow end-to-end against a real PR (#738) via `workflow_dispatch` — baselines regenerated, stale regression comment cleared, required checks reported on the new commit.
- The label-triggered path itself needs one live verification: add `needs screenshots` to an open PR once this merges and confirm the job fires, resolves the correct branch/PR context, and removes the label when done.
- `pnpm check-types`, lint, and prettier all pass on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_019i3vhP6NqFRu647bYS3CUG)_