### PR TITLE
fix(e2e): pin publishedAt in e2e seed to stop visual-baseline drift

### DIFF
--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -17,7 +17,7 @@ const ctx = { disableRevalidate: true }
 
 // Screenshot baselines bake in this date via the article/volume byline, so it
 // must stay fixed rather than tracking the day the seed happens to run.
-const PUBLISHED_AT = "2026-06-02T00:00:00.000Z"
+const PUBLISHED_AT = "2026-06-04T00:00:00.000Z"
 
 export async function main(): Promise<void> {
   const payload = await getPayload({ config })

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -15,6 +15,10 @@ import { getPayload } from "payload"
 
 const ctx = { disableRevalidate: true }
 
+// Screenshot baselines bake in this date via the article/volume byline, so it
+// must stay fixed rather than tracking the day the seed happens to run.
+const PUBLISHED_AT = "2026-06-02T00:00:00.000Z"
+
 export async function main(): Promise<void> {
   const payload = await getPayload({ config })
 
@@ -34,10 +38,17 @@ export async function main(): Promise<void> {
 
     // Typography showcase article (slug: "rich-text-showcase").
     // Pass [] for mediaDocs — all media accesses use ?. so heroImage/meta.image will be null.
-    const articleId = await createRichTextShowcaseArticle(payload, [writer], [], [], ctx)
+    const articleId = await createRichTextShowcaseArticle(
+      payload,
+      [writer],
+      [],
+      [],
+      ctx,
+      PUBLISHED_AT,
+    )
 
     // Interactive map article (slug: "missouri-shifting-margins-119-120-congressional-maps").
-    await createMoCongressionalMapsArticle(payload, [writer], [], [], ctx)
+    await createMoCongressionalMapsArticle(payload, [writer], [], [], ctx, PUBLISHED_AT)
 
     const volume = await payload.create({
       collection: "volumes",
@@ -49,7 +60,7 @@ export async function main(): Promise<void> {
         articles: [articleId],
         slug: "1",
         _status: "published",
-        publishedAt: new Date().toISOString(),
+        publishedAt: PUBLISHED_AT,
       },
     })
 

--- a/src/endpoints/seed/articles.ts
+++ b/src/endpoints/seed/articles.ts
@@ -10,6 +10,7 @@ interface CreateArticleOptions {
   slug: string
   heroImage?: number | null
   narration?: number | null
+  publishedAt?: string
   meta?: {
     title?: string | null
     description?: string | null
@@ -51,7 +52,7 @@ export async function createArticle(
           heroImage: options.heroImage || undefined,
           narration: options.narration || undefined,
           _status: "published",
-          publishedAt: new Date().toISOString(),
+          publishedAt: options.publishedAt || new Date().toISOString(),
           slug: options.slug,
           meta: {
             title: options.meta?.title || options.title,

--- a/src/endpoints/seed/features/interactive-maps/mo-congressional-maps.ts
+++ b/src/endpoints/seed/features/interactive-maps/mo-congressional-maps.ts
@@ -57,6 +57,7 @@ export const createMoCongressionalMapsArticle = async (
   mediaDocs: Media[],
   topics: number[] = [],
   ctx?: Record<string, unknown>,
+  publishedAt?: string,
 ): Promise<number> => {
   validateWriters(writers)
 
@@ -112,6 +113,7 @@ export const createMoCongressionalMapsArticle = async (
       topics,
       slug: "missouri-shifting-margins-119-120-congressional-maps",
       heroImage: mediaDocs[2]?.id ?? mediaDocs[0]?.id,
+      publishedAt,
       meta: {
         title,
         description:

--- a/src/endpoints/seed/features/rich-text-showcase.ts
+++ b/src/endpoints/seed/features/rich-text-showcase.ts
@@ -23,6 +23,7 @@ export const createRichTextShowcaseArticle = async (
   mediaDocs: Media[],
   topics: number[] = [],
   context?: Record<string, unknown>,
+  publishedAt?: string,
 ): Promise<number> => {
   const writer = writers[0]!
 
@@ -256,6 +257,7 @@ export const createRichTextShowcaseArticle = async (
       topics,
       slug: "rich-text-showcase",
       heroImage: mediaDocs[Math.floor(Math.random() * mediaDocs.length)]?.id,
+      publishedAt,
       meta: {
         title,
         description:

--- a/tests/scripts/seed-e2e.test.ts
+++ b/tests/scripts/seed-e2e.test.ts
@@ -65,9 +65,14 @@ describe("seed-e2e main()", () => {
   it("creates the rich-text showcase article with the writer and empty media/topics", async () => {
     await main()
 
-    expect(createRichTextShowcaseArticle).toHaveBeenCalledWith(mockPayload, [mockWriter], [], [], {
-      disableRevalidate: true,
-    })
+    expect(createRichTextShowcaseArticle).toHaveBeenCalledWith(
+      mockPayload,
+      [mockWriter],
+      [],
+      [],
+      { disableRevalidate: true },
+      "2026-06-02T00:00:00.000Z",
+    )
   })
 
   it("creates the interactive map article with the writer and empty media", async () => {
@@ -81,6 +86,7 @@ describe("seed-e2e main()", () => {
       {
         disableRevalidate: true,
       },
+      "2026-06-02T00:00:00.000Z",
     )
   })
 

--- a/tests/scripts/seed-e2e.test.ts
+++ b/tests/scripts/seed-e2e.test.ts
@@ -71,7 +71,7 @@ describe("seed-e2e main()", () => {
       [],
       [],
       { disableRevalidate: true },
-      "2026-06-02T00:00:00.000Z",
+      "2026-06-04T00:00:00.000Z",
     )
   })
 
@@ -86,7 +86,7 @@ describe("seed-e2e main()", () => {
       {
         disableRevalidate: true,
       },
-      "2026-06-02T00:00:00.000Z",
+      "2026-06-04T00:00:00.000Z",
     )
   })
 
@@ -101,6 +101,7 @@ describe("seed-e2e main()", () => {
       slug: "1",
       _status: "published",
       articles: [mockArticleId],
+      publishedAt: "2026-06-04T00:00:00.000Z",
     })
     expect(volumeCall.context).toEqual({ disableRevalidate: true })
   })


### PR DESCRIPTION
## Context

The e2e seed (`scripts/seed-e2e.ts`) stamped seeded articles and volumes with `publishedAt: new Date().toISOString()`, i.e. "today." `ArticleHero` and the volume page both render that date as visible text in the byline (`formatDateTime`), so every screenshot baseline that includes a byline goes stale the day after it's captured — the actual render always shows today's date, the baseline shows whatever day it was generated.

This surfaced while resolving a merge on PR #738: after fixing an unrelated broken merge, E2E visual regression still failed on 4 ShareButtons/volume screenshots. Comparing the `actual` vs `expected` diff images confirmed the only difference was the byline date (baseline captured June 2, 2026; test run on July 4, 2026), not a real UI regression.

**Fix**: `createArticle` (`src/endpoints/seed/articles.ts`) now accepts an optional `publishedAt` override (defaults to `new Date()` as before, so the regular dev/demo seed is unaffected). `createRichTextShowcaseArticle` and `createMoCongressionalMapsArticle` thread an optional `publishedAt` param through to it. `scripts/seed-e2e.ts` pins a fixed `PUBLISHED_AT` date for the seeded articles and volume, so screenshots comparing those bylines stay deterministic regardless of what day CI runs.

Note: this doesn't address `TimeAgo` (relative "x days ago" text used on homepage collection tiles), which is inherently time-relative and would need clock-mocking in Playwright to fully stabilize — out of scope here since it isn't currently causing failures.

## Test Plan

- `pnpm check-types`, `pnpm lint:ci`, `pnpm test:unit` all pass
- Existing seed call sites (`src/endpoints/seed/index.ts`) don't pass the new optional param, so the regular dev seed keeps using `new Date()` — no behavior change there
- Once merged, PR #738's E2E run should stop failing on `article-share-trigger`, `volume-share-popover-open`, `article-share-popover-close-up`, and `article-share-popover-open` (may still need one baseline refresh to adopt the new fixed date)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DSQPFPpNkPtY6eUoRa2J7t)_