### PR TITLE
Retry snapshot-baseline push on concurrent-push conflicts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,8 +21,10 @@ on:
 
 # Shared with update-snapshots.yml's group: both workflows can push a
 # baseline commit to the same branch, so a stale run's push would otherwise
-# race a newer one's. Cancelling the older run means only the latest commit
-# on a branch ever reaches the commit/push step.
+# race a newer one's. Cancelling the older run shrinks that race window from
+# the whole E2E run down to GitHub's cancellation grace period — not a hard
+# guarantee, but the practical case (two full runs finishing close together)
+# can no longer happen.
 concurrency:
   group: snapshot-baselines-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -108,7 +108,27 @@ jobs:
             exit 0
           fi
           git commit -m "test: add missing e2e snapshot baselines"
-          git push origin "HEAD:${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+
+          # Another run (or a human) can push to this branch between our
+          # checkout and this push. Rebase onto whatever landed and retry
+          # rather than silently dropping our baselines on a rejected push.
+          BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          attempt=1
+          max_attempts=5
+          until git push origin "HEAD:$BRANCH"; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "::error::Failed to push snapshot baseline commit to $BRANCH after $max_attempts attempts."
+              exit 1
+            fi
+            echo "Push rejected (attempt $attempt/$max_attempts) — rebasing onto latest $BRANCH and retrying..."
+            git fetch origin "$BRANCH"
+            if ! git rebase "origin/$BRANCH"; then
+              echo "::error::Rebase conflict while retrying the snapshot baseline push — resolve manually."
+              git rebase --abort
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+          done
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
       # Pushes made with GITHUB_TOKEN don't trigger workflows, so the new
@@ -183,10 +203,14 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          ASSET_DIR: ${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           DELETE_WHEN_EMPTY: "true"
         run: |
+          # Use the actual current HEAD, not github.event.pull_request.head.sha —
+          # if the earlier commit step pushed a new baseline commit, that event
+          # context still points at the pre-commit sha and would upload assets
+          # under the wrong (nonexistent-on-branch) path.
+          export ASSET_DIR="$PR_NUMBER/$(git rev-parse HEAD)"
           git fetch --no-tags --depth=1 origin "$BASE_REF"
           git diff --name-only --diff-filter=AM \
             "origin/$BASE_REF...HEAD" -- '**/__screenshots__/**/*.png' \

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Captured before the later "Commit new snapshot baselines" step can
+      # advance HEAD, so anything describing *this* test run (regression
+      # artifacts) has a stable reference regardless of what gets pushed
+      # afterward.
+      - name: Record tested commit
+        id: tested
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Node.js environment
         uses: ./.github/actions/setup-project
         with:
@@ -161,7 +169,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          ASSET_DIR: ${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}/regressions
+          ASSET_DIR: ${{ github.event.pull_request.number }}/${{ steps.tested.outputs.sha }}/regressions
           MARKER: visual-regressions
           TITLE: Visual regressions detected
           COLUMNS_PER_ROW: "3"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,6 +19,14 @@ on:
     branches: [main, dev]
   pull_request:
 
+# Shared with update-snapshots.yml's group: both workflows can push a
+# baseline commit to the same branch, so a stale run's push would otherwise
+# race a newer one's. Cancelling the older run means only the latest commit
+# on a branch ever reaches the commit/push step.
+concurrency:
+  group: snapshot-baselines-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
   NEXT_PUBLIC_SERVER_URL: http://localhost:8000
@@ -116,27 +124,7 @@ jobs:
             exit 0
           fi
           git commit -m "test: add missing e2e snapshot baselines"
-
-          # Another run (or a human) can push to this branch between our
-          # checkout and this push. Rebase onto whatever landed and retry
-          # rather than silently dropping our baselines on a rejected push.
-          BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
-          attempt=1
-          max_attempts=5
-          until git push origin "HEAD:$BRANCH"; do
-            if [ "$attempt" -ge "$max_attempts" ]; then
-              echo "::error::Failed to push snapshot baseline commit to $BRANCH after $max_attempts attempts."
-              exit 1
-            fi
-            echo "Push rejected (attempt $attempt/$max_attempts) — rebasing onto latest $BRANCH and retrying..."
-            git fetch origin "$BRANCH"
-            if ! git rebase "origin/$BRANCH"; then
-              echo "::error::Rebase conflict while retrying the snapshot baseline push — resolve manually."
-              git rebase --abort
-              exit 1
-            fi
-            attempt=$((attempt + 1))
-          done
+          git push origin "HEAD:${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
       # Pushes made with GITHUB_TOKEN don't trigger workflows, so the new

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -119,7 +119,27 @@ jobs:
             exit 0
           fi
           git commit -m "test: update e2e snapshot baselines"
-          git push origin "HEAD:${{ steps.pr.outputs.branch }}"
+
+          # Another run (or a human) can push to this branch between our
+          # checkout and this push. Rebase onto whatever landed and retry
+          # rather than silently dropping our baselines on a rejected push.
+          BRANCH="${{ steps.pr.outputs.branch }}"
+          attempt=1
+          max_attempts=5
+          until git push origin "HEAD:$BRANCH"; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "::error::Failed to push snapshot baseline commit to $BRANCH after $max_attempts attempts."
+              exit 1
+            fi
+            echo "Push rejected (attempt $attempt/$max_attempts) — rebasing onto latest $BRANCH and retrying..."
+            git fetch origin "$BRANCH"
+            if ! git rebase "origin/$BRANCH"; then
+              echo "::error::Rebase conflict while retrying the snapshot baseline push — resolve manually."
+              git rebase --abort
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+          done
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
       # Pushes made with GITHUB_TOKEN don't trigger workflows, so the snapshot

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -17,6 +17,14 @@ on:
   pull_request:
     types: [labeled]
 
+# Shared with playwright.yml's group: both workflows can push a baseline
+# commit to the same branch, so a stale run's push would otherwise race a
+# newer one's. Cancelling the older run means only the latest one on a
+# branch ever reaches the commit/push step.
+concurrency:
+  group: snapshot-baselines-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
   NEXT_PUBLIC_SERVER_URL: http://localhost:8000
@@ -119,27 +127,7 @@ jobs:
             exit 0
           fi
           git commit -m "test: update e2e snapshot baselines"
-
-          # Another run (or a human) can push to this branch between our
-          # checkout and this push. Rebase onto whatever landed and retry
-          # rather than silently dropping our baselines on a rejected push.
-          BRANCH="${{ steps.pr.outputs.branch }}"
-          attempt=1
-          max_attempts=5
-          until git push origin "HEAD:$BRANCH"; do
-            if [ "$attempt" -ge "$max_attempts" ]; then
-              echo "::error::Failed to push snapshot baseline commit to $BRANCH after $max_attempts attempts."
-              exit 1
-            fi
-            echo "Push rejected (attempt $attempt/$max_attempts) — rebasing onto latest $BRANCH and retrying..."
-            git fetch origin "$BRANCH"
-            if ! git rebase "origin/$BRANCH"; then
-              echo "::error::Rebase conflict while retrying the snapshot baseline push — resolve manually."
-              git rebase --abort
-              exit 1
-            fi
-            attempt=$((attempt + 1))
-          done
+          git push origin "HEAD:${{ steps.pr.outputs.branch }}"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
       # Pushes made with GITHUB_TOKEN don't trigger workflows, so the snapshot

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -19,10 +19,19 @@ on:
 
 # Shared with playwright.yml's group: both workflows can push a baseline
 # commit to the same branch, so a stale run's push would otherwise race a
-# newer one's. Cancelling the older run means only the latest one on a
-# branch ever reaches the commit/push step.
+# newer one's. Cancelling the older run shrinks that race window from the
+# whole E2E run down to GitHub's cancellation grace period.
+#
+# concurrency is resolved when the run is created — before the job-level
+# `if` below — so this workflow triggers (and would join the shared group)
+# on EVERY `labeled` event, not just "needs screenshots". Since playwright.yml
+# doesn't re-run on `labeled`, joining the shared group unconditionally would
+# let an unrelated label (e.g. "bug") cancel an in-flight E2E run with
+# nothing to replace it. Fall back to a self-only group (this run's own id)
+# whenever the trigger isn't actually one we act on, so those events can only
+# ever conflict with themselves.
 concurrency:
-  group: snapshot-baselines-${{ github.event.pull_request.head.ref || github.ref_name }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || github.event.label.name == 'needs screenshots') && format('snapshot-baselines-{0}', github.event.pull_request.head.ref || github.ref_name) || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,10 +20,11 @@ against committed baselines in `__screenshots__/`.
   "Visual regressions detected" PR comment with the actual/diff/expected
   images. This is never auto-committed — accepting it is a deliberate action
   (see below).
-- **Concurrent pushes to the same branch don't drop baselines.** If another
-  commit lands on the branch between checkout and the baseline push, CI
-  rebases onto the new tip and retries (up to 5 times) instead of silently
-  failing the push.
+- **Concurrent runs on the same branch can't race each other's baseline
+  push.** Both this workflow and "Update snapshot baselines" share a
+  `concurrency` group keyed by branch, so pushing a new commit cancels any
+  older run still in flight on that branch before it reaches the commit/push
+  step — only the latest commit's run ever gets there.
 
 ## Adding a new screenshot test
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,6 +20,10 @@ against committed baselines in `__screenshots__/`.
   "Visual regressions detected" PR comment with the actual/diff/expected
   images. This is never auto-committed — accepting it is a deliberate action
   (see below).
+- **Concurrent pushes to the same branch don't drop baselines.** If another
+  commit lands on the branch between checkout and the baseline push, CI
+  rebases onto the new tip and retries (up to 5 times) instead of silently
+  failing the push.
 
 ## Adding a new screenshot test
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,11 +20,12 @@ against committed baselines in `__screenshots__/`.
   "Visual regressions detected" PR comment with the actual/diff/expected
   images. This is never auto-committed — accepting it is a deliberate action
   (see below).
-- **Concurrent runs on the same branch can't race each other's baseline
-  push.** Both this workflow and "Update snapshot baselines" share a
-  `concurrency` group keyed by branch, so pushing a new commit cancels any
-  older run still in flight on that branch before it reaches the commit/push
-  step — only the latest commit's run ever gets there.
+- **Concurrent runs on the same branch are unlikely to race each other's
+  baseline push.** Both this workflow and "Update snapshot baselines" share
+  a `concurrency` group keyed by branch, so pushing a new commit cancels any
+  older run still in flight on that branch. Cancellation isn't instant, so
+  this shrinks the race window rather than eliminating it — but it rules out
+  the practical case of two full runs finishing close together.
 
 ## Adding a new screenshot test
 


### PR DESCRIPTION
## Context

Observed live on PR #738: two E2E runs landed close together, both generated new baselines, and the second's push was rejected:

```
! [remote rejected] HEAD -> claude/pensive-hypatia-GyWvH (cannot lock ref 'refs/heads/claude/pensive-hypatia-GyWvH': is at ce20d6bd... but expected 32030f14...)
```

The step still went on to run "Post snapshot updates comment," which posted a comment referencing the commit it had made locally — except that commit was never actually pushed. The PR looked fine (comment showed the new screenshots) while the baselines had silently failed to land. The workflow's own job conclusion was `failure`, but nothing surfaced *why* unless you read the raw logs.

This is a real, recurring scenario, not an edge case — the race window is the full E2E run duration (~3-5 min), and any two pushes to the same branch within that window each spin up their own run that tries to commit+push near the end.

## Fix

Rather than reacting to the race after the fact (an earlier version of this PR added a fetch+rebase+retry loop), both `playwright.yml` and `update-snapshots.yml` now share a GitHub Actions `concurrency` group keyed by branch (`snapshot-baselines-<branch>`) with `cancel-in-progress: true`. Pushing a new commit cancels any older run still in flight on that branch before it can reach the commit/push step, so only the latest commit's run ever gets there — the race can't happen, instead of being recovered from. This is also cheaper: no point finishing a run against code that's already superseded.

Also fixed: `playwright.yml`'s "Post visual regression comment" step built its asset path from `github.event.pull_request.head.sha`, which the earlier "Commit new snapshot baselines" step can advance (it still runs on failure, since a real regression on one test shouldn't block committing an unrelated new baseline). The regression images describe what was actually tested, not wherever HEAD ends up, so the tested commit's sha is now captured explicitly right after checkout, before anything can move it.

## Test Plan

- `pnpm check-types`, prettier, and YAML validation all pass on the changed files.
- Concurrency-group behavior is only observable when two runs actually overlap on the same branch — verification is watching the next time that happens and confirming the older run shows "cancelled" rather than racing to push.