### PR TITLE
fix(e2e): use --update-snapshots=changed to avoid no-op baseline commits

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -119,8 +119,8 @@ jobs:
           restore-keys: |
             nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 
-      - name: Regenerate every snapshot baseline
-        run: pnpm test:e2e -- --update-snapshots=all --project=chromium
+      - name: Regenerate changed snapshot baselines
+        run: pnpm test:e2e -- --update-snapshots=changed --project=chromium
 
       - name: Commit regenerated snapshots
         id: commit

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -45,14 +45,19 @@ do. A "Snapshot updates in this PR" comment shows what was added.
 
 When a PR run shows "Visual regressions detected" and the diff is expected
 (e.g. you redesigned a component), run the **Update snapshot baselines**
-workflow on that branch to regenerate every baseline in one commit:
+workflow on that branch to update just the baselines that actually differ:
 
 ```sh
 gh workflow run update-snapshots.yml --ref <your-branch>
 ```
 
 (or Actions → Update snapshot baselines → Run workflow, if you'd rather use the
-browser). No inputs needed — it always regenerates all baselines.
+browser). No inputs needed. It runs with `--update-snapshots=changed`, so a
+baseline is only rewritten when the current render actually mismatches it —
+unrelated screenshots aren't touched just because the suite ran again (PNG
+re-encoding isn't byte-deterministic, so a full `--update-snapshots=all` regen
+tends to produce a few noise bytes of diff on every screenshot, not just the
+ones that changed).
 
 On a PR, you can trigger the same thing by adding the **`needs screenshots`**
 label — no CLI or Actions tab needed. The label is removed automatically once

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -54,10 +54,13 @@ gh workflow run update-snapshots.yml --ref <your-branch>
 (or Actions → Update snapshot baselines → Run workflow, if you'd rather use the
 browser). No inputs needed. It runs with `--update-snapshots=changed`, so a
 baseline is only rewritten when the current render actually mismatches it —
-unrelated screenshots aren't touched just because the suite ran again (PNG
-re-encoding isn't byte-deterministic, so a full `--update-snapshots=all` regen
-tends to produce a few noise bytes of diff on every screenshot, not just the
-ones that changed).
+browser). No inputs needed. It runs with `--update-snapshots=changed`, so a
+baseline is only rewritten when the current render actually mismatches it —
+unrelated screenshots aren't touched just because the suite ran again. (A full
+`--update-snapshots=all` regen re-renders and rewrites *every* baseline, and the
+freshly-rendered pixels differ slightly from the committed ones due to
+anti-aliasing / font-hinting jitter — within the `maxDiffPixelRatio` tolerance,
+but enough to produce a few noise bytes of diff on each screenshot.)
 
 On a PR, you can trigger the same thing by adding the **`needs screenshots`**
 label — no CLI or Actions tab needed. The label is removed automatically once


### PR DESCRIPTION
## Context

The **Update snapshot baselines** workflow (triggered via `workflow_dispatch` or the `needs screenshots` label) runs `pnpm test:e2e -- --update-snapshots=all --project=chromium`, which forces Playwright to re-render and re-encode *every* screenshot in the suite, then commits whatever came out different.

The problem: PNG encoding isn't byte-deterministic even when the rendered pixels are identical (font hinting/anti-aliasing jitter, compression noise). This PR's motivating example was PR #738 — its baseline-refresh commit (`b539437`) re-committed `home-page.png`, `interactive-map-tooltip.png`, and `newsletter-footer.png` for a few bytes of diff each, none of which had anything to do with that PR's actual change (ShareButtons). The same pattern shows up in #821 on `dev`.

`--update-snapshots=changed` only rewrites a baseline when the pixel comparison against the existing baseline actually fails (a real visual diff beyond threshold), so unrelated screenshots are left untouched.

## Changes

- `.github/workflows/update-snapshots.yml`: `--update-snapshots=all` → `--update-snapshots=changed`
- `tests/e2e/README.md`: updated the "Accepting an intentional visual change" section to describe the new behavior instead of "it always regenerates all baselines"

## Test Plan

- No code paths beyond CI workflow YAML and docs were touched, so no unit/integration tests apply
- `pnpm format:fix`, `pnpm check-types` pass locally
- Verification requires actually running the **Update snapshot baselines** workflow (or the `needs screenshots` label) on a PR with an intentional visual change, and confirming only the truly-changed screenshots get committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3b6UzYhJxLHoAaLGG1bYP)_