### PR TITLE
fix(docs): run prettier on code-review SKILL.md

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -13,8 +13,8 @@ semicolons, no "this could be more idiomatic TypeScript." If a finding would
 also be caught by ESLint or `tsc`, omit it.
 
 Your job is to find what a diff-only, pattern-matching review misses:
-issues that only become visible once you trace *where a change is actually
-enforced or consumed at runtime*, in *this specific* hosting setup
+issues that only become visible once you trace _where a change is actually
+enforced or consumed at runtime_, in _this specific_ hosting setup
 (self-hosted via Coolify, Cloudflare as the proxy in front, Postgres via
 Drizzle, Payload CMS 3, Next.js 15).
 
@@ -106,13 +106,13 @@ change safe in one can be actively harmful in another:
   `production`, production using S3 storage, staging/preview using local
   volume storage)
 
-For any flagged surface, explicitly ask: *does this behave differently, or
-break, in one of these four contexts but not the others?* Pay particular
+For any flagged surface, explicitly ask: _does this behave differently, or
+break, in one of these four contexts but not the others?_ Pay particular
 attention to:
 
 - Effects that only manifest after a **caching layer has already cached the
   old behavior** (e.g. a long-lived security header like HSTS being cached
-  by browsers — the danger isn't the next deploy, it's the deploy *after*
+  by browsers — the danger isn't the next deploy, it's the deploy _after_
   that, once clients have the policy cached). Call out rollout-sequencing
   risk, not just point-in-time correctness.
 - Effects that depend on **subdomain/wildcard behavior** — does a per-PR


### PR DESCRIPTION
## Summary
`.claude/skills/code-review/SKILL.md` was committed to `dev` with asterisk (`*emphasis*`) markdown emphasis, but this repo's Prettier config normalizes emphasis to underscores (`_emphasis_`). Any branch that merges `dev` and then commits (triggering the pre-commit Prettier pass) flips the file back to underscores — producing a self-perpetuating phantom merge conflict against `dev` on this file alone. This is what was keeping PR #770 stuck in a `dirty` mergeable_state even after merging its conflicts away.

Ran `pnpm exec prettier --write` on just this file; confirmed via `pnpm format` that nothing else in the tree is out of sync.

## Test plan
- [x] `pnpm format` reports all files match Prettier style


---
_Generated by [Claude Code](https://claude.ai/code/session_011L5PzprjRFwSEyudveQwAM)_