### PR TITLE
fix(e2e): wait for images to decode before visual regression screenshots

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -20,12 +20,24 @@ export async function gotoFirstVolume(page: Page): Promise<string | null> {
 
 /**
  * Settle sources of pixel nondeterminism before taking a screenshot: wait for
- * web fonts to finish loading (late font swaps shift every glyph) and for two
+ * web fonts to finish loading (late font swaps shift every glyph), for all
+ * <img>s in the DOM to finish decoding (a still-loading hero image behind a
+ * clipped screenshot region is a common source of flaky diffs), and for two
  * animation frames so in-flight layout/paint work has flushed.
  */
 export async function waitForStableRender(page: Page): Promise<void> {
   await page.evaluate(async () => {
     await document.fonts.ready
+    await Promise.all(
+      Array.from(document.images).map((img) =>
+        img.complete
+          ? img.decode().catch(() => undefined)
+          : new Promise((resolve) => {
+              img.addEventListener("load", resolve, { once: true })
+              img.addEventListener("error", resolve, { once: true })
+            }),
+      ),
+    )
     await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
   })
 }


### PR DESCRIPTION
## Summary
Follow-up to #828, whose E2E check failed on a pre-existing flaky `ShareButtons` screenshot test (`article share button and popover close-up`, ~5-6% pixel diff across all 3 retries) — unrelated to that PR's actual change.

- `waitForStableRender` only awaited `document.fonts.ready` before letting a screenshot test proceed, never image loading.
- The `ShareButtons` popover close-up test clips a viewport-ratio-expanded region around the popover (see `viewportRatioClip`), which on an article page includes the hero image. If that image is still decoding when the screenshot is taken, the capture is nondeterministic.
- Updated `waitForStableRender` to also wait for every `<img>` in the DOM to finish loading/decoding (`img.decode()` for already-loaded images, a `load`/`error` listener otherwise) before the existing double-rAF settle.

This is a general helper used by many visual regression specs, not just `ShareButtons`, so it should reduce flakiness elsewhere too.

## Test plan
- [x] `pnpm check-types`
- [x] `pnpm lint:ci`
- [x] `pnpm exec vitest run --project unit` (279 tests)
- [ ] CI's E2E run on this PR (to confirm the previously-flaky `ShareButtons` screenshot now passes)


---
_Generated by [Claude Code](https://claude.ai/code/session_011L5PzprjRFwSEyudveQwAM)_