### PR TITLE
Add Vercel ignore build script to skip builds on non-main branches

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Vercel "Ignored Build Step" script (wired up via `ignoreCommand` in vercel.json).
+# Exit 1 → proceed with the build; exit 0 → skip it.
+# Builds only run for the main branch or commits attached to a pull request.
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "main" ]]; then
+  echo "✅ Building: commit is on main"
+  exit 1
+fi
+
+if [[ -n "$VERCEL_GIT_PULL_REQUEST_ID" ]]; then
+  echo "✅ Building: commit belongs to PR #$VERCEL_GIT_PULL_REQUEST_ID"
+  exit 1
+fi
+
+echo "🛑 Skipping build: ref '$VERCEL_GIT_COMMIT_REF' is not main and has no open PR"
+exit 0

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh",
   "crons": [
     {
       "path": "/api/payload-jobs/run",


### PR DESCRIPTION
## Context

This PR adds a build optimization for Vercel deployments by implementing an ignore build step that skips unnecessary builds on branches without associated pull requests.

The change introduces a bash script (`scripts/vercel-ignore-build.sh`) that is wired up via the `ignoreCommand` configuration in `vercel.json`. The script implements the following logic:
- **Build** commits on the `main` branch
- **Build** commits that belong to an open pull request
- **Skip** builds for all other branches (e.g., feature branches without PRs)

This reduces build time and deployment costs by preventing redundant builds on branches that aren't being actively reviewed or deployed.

## Test Plan

Vercel will automatically invoke this script on each deployment attempt. The behavior can be verified by:
1. Pushing a commit to a feature branch without a PR → build should be skipped
2. Creating a PR from that branch → build should proceed
3. Pushing to main → build should proceed

The script's exit codes follow Vercel's convention: exit 1 to proceed with build, exit 0 to skip.

https://claude.ai/code/session_013qxjuoUkgwCZzrWmh1SMXP