### PR TITLE
Attention & notification dot system (Layer 1)

### DIFF
--- a/src/Header/Component.tsx
+++ b/src/Header/Component.tsx
@@ -15,9 +15,10 @@ import {
 } from "@/components/ui/sheet"
 import { HeaderActions } from "@/Header/HeaderActions/Component"
 import { SearchForm } from "@/Header/SearchForm/Component"
+import { SearchPanel } from "@/Header/SearchPanel"
 import type { Footer, Header } from "@/payload-types"
 import { getCachedGlobal } from "@/utilities/getGlobals"
-import { TextSearch, User, XIcon } from "lucide-react"
+import { User, XIcon } from "lucide-react"
 import React from "react"
 
 export async function Header(): Promise<React.JSX.Element> {
@@ -31,38 +32,24 @@ export async function Header(): Promise<React.JSX.Element> {
       <header className="bg-background sticky top-0 z-50">
         <div className="container">
           <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 border-b py-3">
-            <Sheet>
-              <SheetTrigger
-                render={
-                  <Button variant="ghost" size="icon">
-                    <TextSearch className="size-6" />
-                    <span className="sr-only">Menu</span>
-                  </Button>
-                }
-              />
-              <SheetContent
-                className="space-y-4 data-[side=left]:w-full data-[side=left]:sm:max-w-sm"
-                side="left"
-                showCloseButton={false}
-              >
-                <SheetHeader className="flex flex-row items-center justify-between">
-                  <SheetTitle className="my-2 md:my-0">
-                    <Logo size="sm" />
-                  </SheetTitle>
-                  <SheetClose
-                    render={
-                      <Button variant="ghost" size="icon-lg">
-                        <XIcon className="size-7" />
-                        <span className="sr-only">Close</span>
-                      </Button>
-                    }
-                  />
-                </SheetHeader>
-                <SearchForm />
-                <Menu menu={navItems} layout="stacked" slot={SheetClose} />
-                <SocialLinks socials={socials} className="px-4 py-3" />
-              </SheetContent>
-            </Sheet>
+            <SearchPanel>
+              <SheetHeader className="flex flex-row items-center justify-between">
+                <SheetTitle className="my-2 md:my-0">
+                  <Logo size="sm" />
+                </SheetTitle>
+                <SheetClose
+                  render={
+                    <Button variant="ghost" size="icon-lg">
+                      <XIcon className="size-7" />
+                      <span className="sr-only">Close</span>
+                    </Button>
+                  }
+                />
+              </SheetHeader>
+              <SearchForm />
+              <Menu menu={navItems} layout="stacked" slot={SheetClose} />
+              <SocialLinks socials={socials} className="px-4 py-3" />
+            </SearchPanel>
             <a
               href="/"
               aria-label="Link to Home"

--- a/src/Header/SearchPanel.tsx
+++ b/src/Header/SearchPanel.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import React from "react"
+import { TextSearch } from "lucide-react"
+
+import { NotificationDot } from "@/components/NotificationDot"
+import { Button } from "@/components/ui/button"
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
+import { useNotification } from "@/providers/NotificationProvider"
+
+export function SearchPanel({ children }: { children: React.ReactNode }): React.ReactNode {
+  const { visible, markSeen } = useNotification("search")
+
+  return (
+    <Sheet>
+      <SheetTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="relative"
+            data-tour="search"
+            onClick={markSeen}
+          >
+            <TextSearch className="size-6" />
+            <span className="sr-only">Menu</span>
+            <NotificationDot visible={visible} />
+          </Button>
+        }
+      />
+      <SheetContent
+        className="space-y-4 data-[side=left]:w-full data-[side=left]:sm:max-w-sm"
+        side="left"
+        showCloseButton={false}
+      >
+        {children}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -2,6 +2,7 @@ import { AdminBar } from "@/components/AdminBar"
 import { Breadcrumbs } from "@/components/Breadcrumbs"
 import { Footer } from "@/Footer/Component"
 import { Header } from "@/Header/Component"
+import { NotificationProvider } from "@/providers/NotificationProvider"
 import { getServerSideURL } from "@/utilities/getURL"
 import { mergeOpenGraph } from "@/utilities/mergeOpenGraph"
 import { cn } from "@/utilities/utils"
@@ -53,13 +54,15 @@ export default async function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <AdminBar />
-          <Header />
-          <main role="main" className="flex-1">
-            <Breadcrumbs />
-            {children}
-          </main>
-          <Footer />
+          <NotificationProvider>
+            <AdminBar />
+            <Header />
+            <main role="main" className="flex-1">
+              <Breadcrumbs />
+              {children}
+            </main>
+            <Footer />
+          </NotificationProvider>
         </ThemeProvider>
       </body>
       <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID} />

--- a/src/app/(frontend)/topics/[slug]/TopicVisitTracker.tsx
+++ b/src/app/(frontend)/topics/[slug]/TopicVisitTracker.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { useNotification } from "@/providers/NotificationProvider"
+import { useEffect } from "react"
+
+export function TopicVisitTracker({ slug }: { slug: string }): null {
+  const { setLastVisited } = useNotification(`topic:${slug}`)
+
+  useEffect(() => {
+    setLastVisited()
+  }, [setLastVisited])
+
+  return null
+}

--- a/src/app/(frontend)/topics/[slug]/page.tsx
+++ b/src/app/(frontend)/topics/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { AuthorArticleCard } from "@/components/Articles/AuthorArticleCard"
 import { LivePreviewListener } from "@/components/LivePreviewListener"
 import { Pagination } from "@/components/Pagination"
 import { PayloadRedirects } from "@/components/PayloadRedirects"
+import { TopicVisitTracker } from "./TopicVisitTracker"
 import type { Volume } from "@/payload-types"
 import { generateMeta } from "@/utilities/generateMeta"
 import { queryTopicBySlug } from "@/utilities/queries"
@@ -133,6 +134,7 @@ export default async function TopicPage({
   return (
     <article className="mx-auto max-w-3xl space-y-6 px-4">
       <PayloadRedirects disableNotFound url={url} />
+      <TopicVisitTracker slug={slug} />
 
       {draft && <LivePreviewListener />}
 

--- a/src/components/MegaMenu/index.tsx
+++ b/src/components/MegaMenu/index.tsx
@@ -1,35 +1,43 @@
+"use client"
+
+import React from "react"
+
+import { NotificationDot } from "@/components/NotificationDot"
 import {
   NavigationMenu,
   NavigationMenuItem,
   NavigationMenuLink,
   NavigationMenuList,
 } from "@/components/ui/navigation-menu"
-import { type MenuField } from "@/payload-types"
 import { CMSLink } from "../Link/CMSLink2"
+import { type MenuField } from "@/payload-types"
+import { useNotification } from "@/providers/NotificationProvider"
 
 interface MegaMenuProps {
   menu?: MenuField
 }
 
+function MegaMenuItem({ item }: { item: NonNullable<MenuField>[number] }): React.ReactNode {
+  const { visible, markSeen } = useNotification(`nav:${item.id}`)
+  return (
+    <NavigationMenuItem>
+      <NavigationMenuLink
+        className="py-1"
+        render={<CMSLink link={item.link} onClick={markSeen} />}
+      />
+      <NotificationDot visible={visible} className="top-0 right-0" />
+    </NavigationMenuItem>
+  )
+}
+
 export function MegaMenu({ menu }: MegaMenuProps): React.ReactNode {
   if (!menu) return null
   return (
-    <div className="my-2 hidden w-full justify-center md:flex">
-      <NavigationMenu
-        align="center"
-        //   className="hidden w-full max-w-full flex-none justify-center md:flex"
-      >
+    <div className="my-2 hidden w-full justify-center md:flex" data-tour="mega-menu">
+      <NavigationMenu align="center">
         <NavigationMenuList className="space-x-1">
-          {/* <NavigationMenuItem>
-      <NavigationMenuTrigger>Item One</NavigationMenuTrigger>
-      <NavigationMenuContent>
-        <NavigationMenuLink>Link</NavigationMenuLink>
-      </NavigationMenuContent>
-    </NavigationMenuItem> */}
           {menu.map((item) => (
-            <NavigationMenuItem key={item.id}>
-              <NavigationMenuLink className="py-1" render={<CMSLink link={item.link} />} />
-            </NavigationMenuItem>
+            <MegaMenuItem key={item.id} item={item} />
           ))}
         </NavigationMenuList>
       </NavigationMenu>

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "@wrksz/themes/client"
 import { Moon, Sun } from "lucide-react"
 import React from "react"
 
+import { NotificationDot } from "@/components/NotificationDot"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -11,18 +12,21 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { useNotification } from "@/providers/NotificationProvider"
 
 export function ModeToggle(): React.JSX.Element {
   const { setTheme } = useTheme()
+  const { visible, markSeen } = useNotification("theme-selector")
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={(open) => open && markSeen()}>
       <DropdownMenuTrigger
         render={
-          <Button variant="ghost" size="icon-sm">
+          <Button variant="ghost" size="icon-sm" className="relative" data-tour="mode-toggle">
             <Sun className="size-5 scale-100 rotate-0 transition-all dark:scale-0 dark:rotate-90" />
             <Moon className="absolute size-5 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
             <span className="sr-only">Toggle theme</span>
+            <NotificationDot visible={visible} />
           </Button>
         }
       />

--- a/src/components/NotificationDot.tsx
+++ b/src/components/NotificationDot.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/utilities/utils"
+import React from "react"
+
+interface NotificationDotProps {
+  visible: boolean
+  className?: string
+}
+
+export function NotificationDot({ visible, className }: NotificationDotProps): React.ReactNode {
+  if (!visible) return null
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "ring-background bg-brand pointer-events-none absolute top-0.5 right-0.5 size-2 rounded-full ring-2",
+        className,
+      )}
+    />
+  )
+}

--- a/src/providers/NotificationProvider.tsx
+++ b/src/providers/NotificationProvider.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import React, { useCallback, useSyncExternalStore } from "react"
+
+const KEY_PREFIX = "pp:"
+
+interface NotificationState {
+  seen: Set<string>
+  lastVisited: Map<string, string>
+  hydrated: boolean
+}
+
+const EMPTY_STATE: NotificationState = Object.freeze({
+  seen: new Set<string>(),
+  lastVisited: new Map<string, string>(),
+  hydrated: false,
+})
+
+// Module-level external store — no React state, no effects
+let _state: NotificationState | null = null
+const _listeners = new Set<() => void>()
+
+function _notify(): void {
+  _listeners.forEach((l) => l())
+}
+
+function _subscribe(listener: () => void): () => void {
+  _listeners.add(listener)
+  return () => _listeners.delete(listener)
+}
+
+function _readFromLocalStorage(): NotificationState {
+  const seen = new Set<string>()
+  const lastVisited = new Map<string, string>()
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (!key?.startsWith(KEY_PREFIX)) continue
+
+    if (key.startsWith(`${KEY_PREFIX}seen:`)) {
+      seen.add(key.slice(`${KEY_PREFIX}seen:`.length))
+    } else if (key.startsWith(`${KEY_PREFIX}lastVisited:`)) {
+      const name = key.slice(`${KEY_PREFIX}lastVisited:`.length)
+      lastVisited.set(name, localStorage.getItem(key) ?? "")
+    }
+  }
+
+  return { seen, lastVisited, hydrated: true }
+}
+
+function _getSnapshot(): NotificationState {
+  if (_state === null) {
+    _state = _readFromLocalStorage()
+  }
+  return _state
+}
+
+function _getServerSnapshot(): NotificationState {
+  return EMPTY_STATE
+}
+
+export interface NotificationHookValue {
+  visible: boolean
+  markSeen: () => void
+  getLastVisited: () => Date | null
+  setLastVisited: () => void
+  loaded: boolean
+}
+
+export function useNotification(name: string): NotificationHookValue {
+  const state = useSyncExternalStore(_subscribe, _getSnapshot, _getServerSnapshot)
+
+  const visible = state.hydrated && !state.seen.has(name)
+
+  const markSeen = useCallback((): void => {
+    localStorage.setItem(`${KEY_PREFIX}seen:${name}`, "1")
+    const current = _getSnapshot()
+    _state = { ...current, seen: new Set(current.seen).add(name) }
+    _notify()
+  }, [name])
+
+  const getLastVisited = useCallback((): Date | null => {
+    const val = state.lastVisited.get(name)
+    return val ? new Date(val) : null
+  }, [name, state.lastVisited])
+
+  const setLastVisited = useCallback((): void => {
+    const now = new Date().toISOString()
+    localStorage.setItem(`${KEY_PREFIX}lastVisited:${name}`, now)
+    const current = _getSnapshot()
+    _state = { ...current, lastVisited: new Map(current.lastVisited).set(name, now) }
+    _notify()
+  }, [name])
+
+  return { visible, markSeen, getLastVisited, setLastVisited, loaded: state.hydrated }
+}
+
+// Thin wrapper kept for layout composition
+export function NotificationProvider({ children }: { children: React.ReactNode }): React.ReactNode {
+  return <>{children}</>
+}


### PR DESCRIPTION
Closes #849. Split out of #804 (the product tour is the companion PR).

## Context

Adds a localStorage-based notification dot system to draw reader attention to key UI features, with no auth required. This is the foundation half of #804, split apart so the dot primitive can be reviewed on its own; the Driver.js product tour follows in a stacked PR (#850).

- **`useNotification(name)`** — single hook returning `{ visible, markSeen, getLastVisited, setLastVisited }`. Pass the namespace key once; all reads/writes are pre-bound. Backed by `useSyncExternalStore` with a `getServerSnapshot`, so there are no SSR hydration mismatches.
- **`NotificationDot`** — purely presentational; takes `visible: boolean`, renders a small dot positioned top-right of its container, returns `null` when hidden.
- **`NotificationProvider`** — thin wrapper kept for layout composition; the real state lives in the module-level `useSyncExternalStore` store.

### Wired up on

| Element | `name` key | Dismissed on |
|---|---|---|
| Mode toggle (footer) | `theme-selector` | Dropdown open |
| Search button (header) | `search` | Button click |
| MegaMenu nav items | `nav:<id>` | Link click |
| Topic pages | `lastVisited:topic:<slug>` | Page visit (for future staleness dots) |

The `data-tour` anchors (`mega-menu`, `search`, `mode-toggle`) are included here as inert DOM attributes so the follow-up tour PR needs no further edits to these components.

### localStorage keys

```
pp:seen:<name>          — boolean, feature interacted with
pp:lastVisited:<name>   — ISO timestamp, last visit
```

## Test Plan

- [ ] Cold visit (incognito): dots visible on the mode toggle, search button, and all nav items
- [ ] Open the mode toggle: its dot disappears and stays gone on refresh (`pp:seen:theme-selector` set)
- [ ] Click the search button: its dot disappears
- [ ] Click a MegaMenu nav item: that item's dot disappears, others remain
- [ ] Visit a topic page: `pp:lastVisited:topic:<slug>` written to localStorage
- [ ] No SSR hydration warnings in the console
- [x] `pnpm check-types` — passes
- [x] `pnpm lint` — passes

## Out of scope

- The Driver.js product tour → #850 (stacked on this branch)
- Syncing state to Payload Users on login, per-topic latest-article API, achievements (Layer 2+)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ETcaG6R6NoruXjziuhnxSr)_