### PR TITLE
fix(sentry): filter third-party errors from browser extensions and CDN scripts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -165,6 +165,11 @@ export default withSentryConfig(withPayload(nextConfig, { devBundleServerPackage
 
   project: "pragmatic-papers",
 
+  // Tags our bundled code with this key so `thirdPartyErrorFilterIntegration`
+  // (in src/instrumentation-client.ts) can tell our frames from third-party ones.
+  // Top-level `applicationKey` injects module metadata for both webpack and Turbopack.
+  applicationKey: "pragmatic-papers",
+
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -17,15 +17,22 @@ Sentry.init({
   sendDefaultPii: true,
 
   integrations: [
-    // Drop errors that originate entirely from scripts we don't ship — browser
+    // Identify errors that originate entirely from scripts we don't ship — browser
     // extensions and Cloudflare-injected code (e.g. the /cdn-cgi/rum beacon that
     // throws `r["@context"].toLowerCase` while parsing our JSON-LD). "Third-party"
     // frames are those not tagged with the `applicationKey` set in next.config.ts.
-    // We use the `exclusively` behaviour so any error with at least one first-party
-    // frame — i.e. anything touching our own code — is always kept.
+    //
+    // Rollout is deliberately two-step. We start with `apply-tag-*`, which drops
+    // NOTHING and only adds a `third_party_code: true` tag — because if the
+    // applicationKey metadata failed to inject (notably on the Turbopack loader
+    // path), a `drop-*` behaviour would classify every frame as third-party and
+    // silently drop ALL client errors. Once we've confirmed in Sentry that real
+    // errors are untagged and third-party ones are tagged, flip this to
+    // `drop-error-if-exclusively-contains-third-party-frames`. Filter the issue
+    // stream in the meantime with `!third_party_code:True`. See PR/issue #855.
     Sentry.thirdPartyErrorFilterIntegration({
       filterKeys: ["pragmatic-papers"],
-      behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+      behaviour: "apply-tag-if-exclusively-contains-third-party-frames",
     }),
   ],
 })

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -15,6 +15,19 @@ Sentry.init({
 
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
+
+  integrations: [
+    // Drop errors that originate entirely from scripts we don't ship — browser
+    // extensions and Cloudflare-injected code (e.g. the /cdn-cgi/rum beacon that
+    // throws `r["@context"].toLowerCase` while parsing our JSON-LD). "Third-party"
+    // frames are those not tagged with the `applicationKey` set in next.config.ts.
+    // We use the `exclusively` behaviour so any error with at least one first-party
+    // frame — i.e. anything touching our own code — is always kept.
+    Sentry.thirdPartyErrorFilterIntegration({
+      filterKeys: ["pragmatic-papers"],
+      behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+    }),
+  ],
 })
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart


### PR DESCRIPTION
Closes #855

## Context

Errors that don't originate from our own code are reaching Sentry — and would auto-file GitHub issues once we route errors → issues. The prompting example on `/volumes`:

```
TypeError: undefined is not an object (evaluating 'r["@context"].toLowerCase')
    at ? (app:///volumes:3:185)
    at global code (app:///volumes:3:362)
```

The breadcrumbs show a Cloudflare RUM beacon (`POST /cdn-cgi/rum?`) firing just before the exception, and the failing frame is an **inline, injected script in the served HTML doc** (`app:///volumes:3`, `global code`) — not one of our bundled chunks. It's Cloudflare-injected code choking while parsing our (valid) JSON-LD, not a bug in `JsonLd.tsx`.

This PR enables Sentry's [`thirdPartyErrorFilterIntegration`](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration) to identify errors that come **entirely** from scripts we don't ship (browser extensions, Cloudflare-injected code).

- `src/instrumentation-client.ts` — add the integration with the `exclusively` variant (only acts on errors where **every** frame is third-party, so anything touching our own code is untouched).
- `next.config.ts` — set the top-level `applicationKey` in `withSentryConfig`, which tags our bundled frames as first-party. The top-level option injects module metadata for both webpack and **Turbopack** (our build).

Client-side only; server-side error capture is unaffected.

## Rollout: tag first, drop later

This ships in **tag-only** mode — `behaviour: "apply-tag-if-exclusively-contains-third-party-frames"`, which **drops nothing** and only adds a `third_party_code: true` tag.

Why not drop immediately: if `applicationKey` module-metadata injection silently failed (the Turbopack path is newer and worth confirming), a `drop-*` behaviour would classify **every** frame as third-party and **silently drop all client errors**. Tag-only makes the first deploy zero-risk and doubles as the verification that `applicationKey` works.

**Follow-up (after verifying in Sentry):** flip the one line to `drop-error-if-exclusively-contains-third-party-frames`.

## Test Plan

- `pnpm check-types` — passes
- `pnpm lint:ci` — passes (0 warnings)
- Post-deploy verification (proves `applicationKey` works **and** clears the way for the drop):
  1. In Sentry, confirm the Cloudflare `r["@context"].toLowerCase` error is tagged `third_party_code: true`.
  2. Confirm real errors from our own code (e.g. throw in a page) are **not** tagged. Filter the stream with `!third_party_code:True` to focus on our own errors.
  3. Optional static check on a build: `grep -rl "_sentryBundlerPluginAppKey:pragmatic-papers" .next/static` should match our client chunks.
  4. Once 1–2 hold, open the follow-up to switch to the drop behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPqsco4AFMdmF5AYXbgzQA