### PR TITLE
ci: cancel superseded PR runs and trim per-run overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main, dev]
   pull_request:
 
+# Cancel superseded runs on a PR so a new push doesn't leave the previous
+# commit's Static/Unit/Integration jobs (two Postgres services + Testcontainers)
+# running to completion for nothing. Scoped per-ref. Pushes to main/dev use a
+# per-run group (github.run_id) so they never cancel each other — every commit
+# landing on a protected branch is still validated in full.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   static:
     name: Static checks
@@ -31,9 +40,11 @@ jobs:
           --health-retries 5
 
     steps:
+      # Shallow clone: none of the static checks below read git history
+      # (check-migration-order sorts files by name; check-pending-migrations
+      # runs against the Postgres service), so the default depth-1 fetch is
+      # enough and skips pulling the full history.
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Set up Node.js environment
         uses: ./.github/actions/setup-project

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -91,17 +91,20 @@ jobs:
 
       # The Playwright image doesn't ship the GitHub CLI, but several steps
       # below (committing baselines, posting PR comments via
-      # scripts/pr-screenshot-comment.ts) shell out to `gh`.
+      # scripts/pr-screenshot-comment.ts) shell out to `gh`. Pull the release
+      # tarball straight from GitHub instead of going through the apt repo —
+      # that path ran `apt-get update` twice (a full package-index rebuild
+      # each time, ~20-40s) just to land one static binary. The pinned version
+      # only needs to be recent enough for the `gh api`/`gh run`/`gh pr`
+      # commands used here; bump freely.
       - name: Install GitHub CLI
         run: |
-          (type -p wget >/dev/null || (apt-get update && apt-get install -y wget)) \
-            && mkdir -p -m 755 /etc/apt/keyrings \
-            && wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-            && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-            && mkdir -p -m 755 /etc/apt/sources.list.d \
-            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-            && apt-get update \
-            && apt-get install -y gh
+          GH_VERSION=2.63.2
+          ARCH=$(dpkg --print-architecture)
+          curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" \
+            | tar -xz -C /tmp
+          install "/tmp/gh_${GH_VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh
+          gh --version
 
       # Captured before the later "Commit new snapshot baselines" step can
       # advance HEAD, so anything describing *this* test run (regression

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -88,17 +88,20 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       # The Playwright image doesn't ship the GitHub CLI, but the very next
-      # step (and several after it) shell out to `gh`.
+      # step (and several after it) shell out to `gh`. Pull the release tarball
+      # straight from GitHub instead of going through the apt repo — that path
+      # ran `apt-get update` twice (a full package-index rebuild each time,
+      # ~20-40s) just to land one static binary. The pinned version only needs
+      # to be recent enough for the `gh api`/`gh run`/`gh pr` commands used
+      # here; bump freely.
       - name: Install GitHub CLI
         run: |
-          (type -p wget >/dev/null || (apt-get update && apt-get install -y wget)) \
-            && mkdir -p -m 755 /etc/apt/keyrings \
-            && wget -nv -O- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-            && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-            && mkdir -p -m 755 /etc/apt/sources.list.d \
-            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-            && apt-get update \
-            && apt-get install -y gh
+          GH_VERSION=2.63.2
+          ARCH=$(dpkg --print-architecture)
+          curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" \
+            | tar -xz -C /tmp
+          install "/tmp/gh_${GH_VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh
+          gh --version
 
       # pull_request's $GITHUB_REF_NAME is "<number>/merge", not the branch —
       # resolve the real branch/PR/base once so every later step can rely on


### PR DESCRIPTION
- Add PR-scoped concurrency to ci.yml so a new push cancels the previous
  commit's Static/Unit/Integration jobs instead of running the full set
  (two Postgres services + Testcontainers) to completion. main/dev pushes
  use a per-run group so protected-branch commits are never cancelled.
- Install the GitHub CLI in the E2E workflows from the release tarball
  instead of the apt repo, dropping two full 'apt-get update' index
  rebuilds per run in playwright.yml and update-snapshots.yml.
- Shallow-clone the static-checks job; none of its checks read git
  history.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DSVqqHgyzh3dc9sPidQeCM