### PR TITLE
ci: enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,14 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  # Keep GitHub Actions used in workflows (.github/workflows) and composite
+  # actions (.github/actions) up to date. Grouped into a single weekly PR.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Context

Our workflow action versions have drifted and gone inconsistent because nothing keeps them updated — e.g. both `actions/checkout@v4` and `@v6`, and both `actions/upload-artifact@v4` and `@v7` are in use across workflows today.

The idiomatic fix is Dependabot's `github-actions` package ecosystem. We already run Dependabot for npm, so this is a one-block addition to `.github/dependabot.yml` rather than a new tool or a custom scheduled workflow.

This PR adds the `github-actions` ecosystem with `directory: "/"` (which covers both `.github/workflows/**` and the composite action under `.github/actions/**`), on a weekly schedule, with all action bumps grouped into a single PR to keep the noise down.

Closes #868

### Follow-up (not in this PR)

Once Dependabot opens its first PR, reconcile the split versions (`checkout` v4/v6, `upload-artifact` v4/v7) so everything lands on one version.

## Test Plan

- `.github/dependabot.yml` is valid YAML and parses as a Dependabot v2 config.
- After merge, confirm Dependabot picks up the new ecosystem under the repo's **Insights → Dependency graph → Dependabot** tab (or trigger a manual check), and that it opens a single grouped `github-actions` PR rather than one per action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZydAQEBY5wGQSprWvqid5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZydAQEBY5wGQSprWvqid5)_